### PR TITLE
Update product image format, hcp logo & newsbrief image heights

### DIFF
--- a/packages/common/components/blocks/standard/product-list.marko
+++ b/packages/common/components/blocks/standard/product-list.marko
@@ -86,16 +86,14 @@ $ const queryParams = {
                                             "color": "#333333",
                                             "font-size": "14px",
                                             "width": "176px",
-                                            "height": "132px",
-                                            "max-width": "176px",
                                           };
                                           <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
                                             <marko-newsletter-imgix
                                               src=image.src
                                               alt=image.alt
-                                              options={ w: 176, h: 132, fit: "crop" }
+                                              options={ w: 176 }
                                               class="img-max"
-                                              attrs={ style: imgStyles, border: 0, width: 176, height: 132 }
+                                              attrs={ style: imgStyles, border: 0, width: 176 }
                                             >
                                               <@link href=content.siteContext.url target="_blank" />
                                             </marko-newsletter-imgix>

--- a/tenants/all/config/brands.js
+++ b/tenants/all/config/brands.js
@@ -16,8 +16,8 @@ module.exports = {
     logoSrc: '/files/base/pmmi/all/image/newsletters/hcp-logo.png',
     subscribeLink: 'https://pmmi.dragonforms.com/loading.do?pk=HCPMagNav&oly_enc_id=@{encrypted_customer_id}@&omedasite=HCPnew',
     logoConfig: {
-      logoAttrs: { width: 139, height: 35 },
-      logoStyle: { 'max-width': '139px', width: '139px', height: '35px' },
+      logoAttrs: { width: 139, height: 39 },
+      logoStyle: { 'max-width': '139px', width: '139px', height: '39px' },
       logoWrapperStyle: { padding: '8px 10px 10px 10px' },
       logoOptions: { w: 139 },
       logoSrc: '/files/base/pmmi/all/image/newsletters/hcp-logo.png',

--- a/tenants/all/templates/hcp-newsbrief.marko
+++ b/tenants/all/templates/hcp-newsbrief.marko
@@ -17,10 +17,10 @@ $ const logoConfig = get(newsletterConfig, "logoConfig");
       newsletter=newsletter
       date=date
       ...logoConfig
-      image-wrapper-style={ "padding": "16px 10px 16px 10px" }
-      image-attrs={ width: 141, height: 27 }
-      image-style={ "max-width": "141px", "width": "141px", "height": "27px" }
-      image-options={ w: 141, h: 27 }
+      image-wrapper-style={ "padding": "12px 10px 10px 10px" }
+      image-attrs={ width: 141, height: 35 }
+      image-style={ "max-width": "141px", "width": "141px", "height": "35px" }
+      image-options={ w: 141, h: 35 }
       image-src="/files/base/pmmi/all/image/newsletters/hcp-newsbrief-header.png"
       secondary-background-color="#00c6e7"
     />


### PR DESCRIPTION
<img width="716" alt="Screen Shot 2021-05-28 at 8 14 59 AM" src="https://user-images.githubusercontent.com/2855198/119989670-0e87b200-bf8d-11eb-85de-e405bc35c011.png">
<img width="705" alt="Screen Shot 2021-05-28 at 8 14 39 AM" src="https://user-images.githubusercontent.com/2855198/119989719-1ba4a100-bf8d-11eb-8eb9-cbb8f42547ce.png">
