### PR TITLE
Update new header

### DIFF
--- a/tenants/all/templates/hcp-quick-hits.marko
+++ b/tenants/all/templates/hcp-quick-hits.marko
@@ -10,7 +10,7 @@ $ const { newsletter, date } = data;
     <common-numeric-header-block
       newsletter=newsletter
       date=date
-      image-src="/files/base/pmmi/all/image/newsletters/hcp-quick-hits-header.png"
+      image-src="/files/base/pmmi/all/image/newsletters/hcp-quick-hits-2021-header.png"
       primary-background-color="#ffffff"
       secondary-background-color="#afd3e3"
       secondary-font-size="12.5px"


### PR DESCRIPTION

<img width="1455" alt="Screen Shot 2021-07-22 at 7 16 09 AM" src="https://user-images.githubusercontent.com/64623209/126637833-db1baf83-ca46-4019-8ceb-3c94aa5b9a1e.png">

This header will now be seen in “dark mode”