### PR TITLE
Fix spelling of ‘newsbrief’ in native-x.js file

### DIFF
--- a/tenants/all/config/native-x.js
+++ b/tenants/all/config/native-x.js
@@ -73,7 +73,7 @@ module.exports = {
       'slot-4': '6010d8bc717cf6000135b8c6',
       'slot-5': '6010d8c0a80e1f000185cc3c',
     },
-    'hcp-news-brief': {
+    'hcp-newsbrief': {
       'top-audience-banner': '6010d853a80e1f000185c3da',
       'slot-1': '6010d857717cf6000135b179',
       'slot-2': '6010d85aa80e1f000185c47a',


### PR DESCRIPTION
Top Banner Ad now showing:
<img width="728" alt="Screen Shot 2022-01-11 at 7 07 54 AM" src="https://user-images.githubusercontent.com/64623209/148948125-67b1f151-8fdd-4542-b0d0-185e5de9b90a.png">
