### PR TITLE
Adjust image styles for announcement block

### DIFF
--- a/packages/common/components/blocks/standard/announcement.marko
+++ b/packages/common/components/blocks/standard/announcement.marko
@@ -37,8 +37,7 @@ $ const imgStyles = {
                           <marko-newsletter-imgix
                             src=image.src
                             alt=image.alt
-                            options={ w: 60, fit: "crop" }
-                            attrs={ height: "auto" }
+                            options={ w: 60, h: 60, fit: "fill" }
                           />
                         </marko-core-obj-value>
                       </td>


### PR DESCRIPTION
<img width="661" alt="Screen Shot 2022-01-11 at 2 11 57 PM" src="https://user-images.githubusercontent.com/64623209/149014368-8212de43-3821-4770-aac3-9baa31973cd2.png">
