### PR TITLE
Correct tagline background and text colors.

### DIFF
--- a/packages/common/components/blocks/standard/header.marko
+++ b/packages/common/components/blocks/standard/header.marko
@@ -8,7 +8,7 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const newsletterName = get(newsletterConfig, "name");
 $ const newsletterDescription = get(newsletterConfig, "description");
 $ const brandName = get(newsletterConfig, "brandName");
-$ const secondaryBackgroundColor = get(newsletterConfig, "secondaryBackgroundColor");
+$ const secondaryBackgroundColor = get(newsletterConfig, "secondaryBackgroundColor") || input.secondaryBackgroundColor;
 $ const lang = get(newsletterConfig, "lang");
 $ const displayDate = (lang) ? moment(date).locale(lang).format("LL") : moment(date).format("LL");
 
@@ -133,6 +133,7 @@ $ const logoLinkStyle = {
                   "background-color": secondaryBackgroundColor || "#005bab",
                   "padding": "6px 12px",
                 }
+                $ const taglineTextColor = input.taglineTextColor || '#ffffff';
                 <td style=secondaryHeaderWrapperStyle>
                   <table border="0" cellpadding="0" cellspacing="0" width="100%">
                     <tr>
@@ -140,7 +141,7 @@ $ const logoLinkStyle = {
                       <td width="70%" align="left" valign="top">
                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
                           <tr>
-                            <td align="left" class="mobile-tagline" style="color: #ffffff; font-family: Helvetica, Arial, sans-serif; font-size: 12.5px; font-weight: normal; line-height: 12.5px; padding: 4px 8px 4px 0;text-align: left">
+                            <td align="left" class="mobile-tagline" style=`color: ${taglineTextColor}; font-family: Helvetica, Arial, sans-serif; font-size: 12.5px; font-weight: normal; line-height: 12.5px; padding: 4px 8px 4px 0;text-align: left`>
                               $!{newsletterDescription}
                             </td>
                           </tr>
@@ -151,7 +152,7 @@ $ const logoLinkStyle = {
                       <td width="25%" align="right" valign="top">
                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
                           <tr>
-                            <td align="right" class="mobile-tagline" style="color: #ffffff; font-family: Helvetica, Arial, sans-serif; font-size: 12.5px; font-weight: normal; line-height: 12.5px; padding: 4px 0 4px 8px;text-align: right;" valign="middle">
+                            <td align="right" class="mobile-tagline" style=`color: ${taglineTextColor}; font-family: Helvetica, Arial, sans-serif; font-size: 12.5px; font-weight: normal; line-height: 12.5px; padding: 4px 0 4px 8px;text-align: right;` valign="middle">
                               ${i18n(displayDate)}
                             </td>
                           </tr>

--- a/packages/common/components/blocks/standard/header.marko
+++ b/packages/common/components/blocks/standard/header.marko
@@ -8,7 +8,6 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const newsletterName = get(newsletterConfig, "name");
 $ const newsletterDescription = get(newsletterConfig, "description");
 $ const brandName = get(newsletterConfig, "brandName");
-$ const secondaryBackgroundColor = get(newsletterConfig, "secondaryBackgroundColor") || input.secondaryBackgroundColor;
 $ const lang = get(newsletterConfig, "lang");
 $ const displayDate = (lang) ? moment(date).locale(lang).format("LL") : moment(date).format("LL");
 
@@ -130,7 +129,7 @@ $ const logoLinkStyle = {
               <!--[if gte mso 12]><br style="line-height:0px; font-size:0px; mso-line-height-rule:exactly;" /> <![endif]-->
               <tr>
                 $ const secondaryHeaderWrapperStyle = {
-                  "background-color": secondaryBackgroundColor || "#005bab",
+                  "background-color": input.secondaryBackgroundColor || "#005bab",
                   "padding": "6px 12px",
                 }
                 $ const taglineTextColor = input.taglineTextColor || '#ffffff';

--- a/tenants/all/templates/aw-process-automation.marko
+++ b/tenants/all/templates/aw-process-automation.marko
@@ -23,6 +23,7 @@ $ const logoConfig = get(newsletterConfig, "logoConfig");
       image-options={ w: 264 }
       image-src="/files/base/pmmi/all/image/newsletters/aw-process-automation-header.png"
       secondary-background-color="#d9d63b"
+      tagline-text-color="#444444"
     />
   </@header>
 </common-standard-layout>

--- a/tenants/mundo/config/core.js
+++ b/tenants/mundo/config/core.js
@@ -13,7 +13,6 @@ const config = {
   'mundo-perspectivas': {
     name: 'Perspectivas',
     description: 'Inteligencia de mercados, tecnologías y tendencias',
-    secondaryBackgroundColor: '#004261',
     lang: 'es',
     ...brands.mundo,
   },

--- a/tenants/mundo/templates/mundo-perspectivas.marko
+++ b/tenants/mundo/templates/mundo-perspectivas.marko
@@ -20,6 +20,7 @@ $ const { newsletter, date } = data;
       image-style={ "max-width": "194px" }
       image-options={ w: 194 }
       image-src="/files/base/pmmi/all/image/newsletters/mundo-perspectivas-header.png"
+      secondary-background-color= "#004261"
     />
   </@header>
   <@footer>


### PR DESCRIPTION
The background colors were not being set correctly due to a breaking change here: https://github.com/jwade1327/pmmi-media-group-newsletters/commit/1ebfc22378e2e996869b45dc1356680daf7b7771 that was looking for secondaryBackgroundColor to be set on all newsletter configurations which it currently is not. 

EDITED: The change in this PR will use the previously used behavior of passing the secondaryBackground color as an input to the header (Mundo's configuration has been updated accordingly) and additionally adding an input parameter for taglineTextColor which will allow the alteration of the tagline text color.

<img width="1792" alt="Screen Shot 2022-01-17 at 8 26 37 AM" src="https://user-images.githubusercontent.com/46794001/149787622-0a004363-6b15-4557-80d6-0a4f02e50850.png">

<img width="1792" alt="Screen Shot 2022-01-17 at 8 38 36 AM" src="https://user-images.githubusercontent.com/46794001/149789822-8a56c701-5ede-4704-bac0-175a2f1144e7.png">

