### PR TITLE
Correct new template header image sizing.

### DIFF
--- a/tenants/all/templates/pfw-hand-picked.marko
+++ b/tenants/all/templates/pfw-hand-picked.marko
@@ -17,7 +17,7 @@ $ const logoConfig = get(newsletterConfig, "logoConfig");
       newsletter=newsletter
       date=date
       ...logoConfig
-      image-attrs={ width: 220, height: 53 }
+      image-attrs={ width: 220, height: 70 }
       image-style={ "max-width": "220px" }
       image-options={ w: 220 }
       image-wrapper-style={ "padding": "8px 10px 6px 10px" }

--- a/tenants/all/templates/pfw-new-issue-alert.marko
+++ b/tenants/all/templates/pfw-new-issue-alert.marko
@@ -17,9 +17,9 @@ $ const logoConfig = get(newsletterConfig, "logoConfig");
       newsletter=newsletter
       date=date
       ...logoConfig
-      image-attrs={ width: 220, height: 53 }
-      image-style={ "max-width": "220px" }
-      image-options={ w: 220 }
+      image-attrs={ width: 191, height: 53 }
+      image-style={ "max-width": "191px" }
+      image-options={ w: 191 }
       image-wrapper-style={ "padding": "8px 10px 6px 10px" }
       image-src="/files/base/pmmi/all/image/newsletters/pfw-new-issue-alert.png"
       secondary-background-color="#8eae3d"


### PR DESCRIPTION
This should (hopefully) prevent the distortion described/shown previously by these header images.

Previously:
<img width="1792" alt="Screen Shot 2022-03-22 at 8 33 35 AM" src="https://user-images.githubusercontent.com/46794001/159495996-d70bda88-4938-450b-b3ab-b1ea892ac1a7.png">
<img width="1920" alt="Screen Shot 2022-03-22 at 8 42 24 AM" src="https://user-images.githubusercontent.com/46794001/159496016-fc573507-8be4-4a81-b230-15ad534a9519.png">


Now:
<img width="1792" alt="Screen Shot 2022-03-22 at 8 33 28 AM" src="https://user-images.githubusercontent.com/46794001/159496085-1777db86-29cb-4eed-b075-0bc1d04df778.png">
<img width="1920" alt="Screen Shot 2022-03-22 at 8 42 19 AM" src="https://user-images.githubusercontent.com/46794001/159496101-138b9685-0a06-493b-9f84-37337dac8d48.png">

