### PR TITLE
Adjust image alignment based on campaign type.

### DIFF
--- a/packages/common/components/blocks/standard/announcement.marko
+++ b/packages/common/components/blocks/standard/announcement.marko
@@ -30,6 +30,11 @@ $ const imgDimensions = {
   "pmmi.dragonforms.com": { w: 60, h: 60 },
 }
 
+$ const imgAlignment = {
+  "youtube.com": { "padding-right": "10px" },
+  "pmmi.dragonforms.com": { "padding-right":  "10px", "padding-top": "8px" }
+}
+
 $ const imgOptions =  {
   w: 60,
   h: 60,
@@ -49,7 +54,7 @@ $ const imgOptions =  {
                   <!-- content left -->
                   <table align="left" border="0" cellpadding="0" cellspacing="0" width="22%">
                     <tr>
-                      <td align="right" style="padding-right: 10px;padding-top: 8px;" valign="top">
+                      <td align="right" style=imgAlignment valign="top">
                         <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
                           <marko-newsletter-imgix
                             src=image.src


### PR DESCRIPTION
Change is super subtle here:

BEFORE:
<img width="1920" alt="Screen Shot 2022-03-28 at 3 20 56 PM" src="https://user-images.githubusercontent.com/46794001/160480602-958e12f0-ad48-4a50-89fd-3dd0bf4e0506.png">


AFTER:
<img width="1920" alt="Screen Shot 2022-03-28 at 3 21 28 PM" src="https://user-images.githubusercontent.com/46794001/160480636-44db093e-b613-48d4-a17b-f09e76ce5579.png">

