### PR TITLE
Change numeric footer over to the new numeric footer.

### DIFF
--- a/packages/common/components/layouts/numeric-new.marko
+++ b/packages/common/components/layouts/numeric-new.marko
@@ -116,6 +116,6 @@ $ const queryParams = {
         </tr>
     </table>
 
-    <common-numeric-footer-block newsletter=newsletter date=date />
+    <common-numeric-footer-new-block newsletter=newsletter date=date />
   </@body>
 </marko-newsletter-root>


### PR DESCRIPTION
LIVE:
<img width="1920" alt="Screen Shot 2022-03-31 at 11 01 29 AM" src="https://user-images.githubusercontent.com/46794001/161101704-21fce14e-f6c1-4a62-8b23-3f7455887cac.png">

DEV:
<img width="1920" alt="Screen Shot 2022-03-31 at 11 10 47 AM" src="https://user-images.githubusercontent.com/46794001/161101729-3d884586-18a0-417a-9b53-e5f35d7a386a.png">

