### PR TITLE
Set row widths back to 100% New Numeric Template

### DIFF
--- a/packages/common/components/blocks/numeric/row-five-new.marko
+++ b/packages/common/components/blocks/numeric/row-five-new.marko
@@ -38,7 +38,7 @@ $ const headlineStyle = {
 
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=true params=queryParams>
     <if(nodes.length)>
-        <table border="0" cellpadding="0" cellspacing="0" width="592 px;">
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
                 <td style="padding-top: 24px;">
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">

--- a/packages/common/components/blocks/numeric/row-four-new.marko
+++ b/packages/common/components/blocks/numeric/row-four-new.marko
@@ -38,7 +38,7 @@ $ const headlineStyle = {
 
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=true params=queryParams>
     <if(nodes.length)>
-        <table border="0" cellpadding="0" cellspacing="0" width="592 px;">
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
                 <td style="padding-top: 24px;">
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">

--- a/packages/common/components/blocks/numeric/row-one-new.marko
+++ b/packages/common/components/blocks/numeric/row-one-new.marko
@@ -38,7 +38,7 @@ $ const headlineStyle = {
 
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=true params=queryParams>
     <if(nodes.length)>
-        <table border="0" cellpadding="0" cellspacing="0" width="592 px;">
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
                 <td style="padding-top: 24px;">
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">

--- a/packages/common/components/blocks/numeric/row-three-new.marko
+++ b/packages/common/components/blocks/numeric/row-three-new.marko
@@ -38,7 +38,7 @@ $ const headlineStyle = {
 
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
     <if(nodes.length)>
-        <table border="0" cellpadding="0" cellspacing="0" width="592 px;">
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
                 <td style="padding-top: 24px;">
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">

--- a/packages/common/components/blocks/numeric/row-two-new.marko
+++ b/packages/common/components/blocks/numeric/row-two-new.marko
@@ -38,7 +38,7 @@ $ const headlineStyle = {
 
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
     <if(nodes.length)>
-        <table border="0" cellpadding="0" cellspacing="0" width="592 px;">
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
                 <td style="padding-top: 24px;">
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">


### PR DESCRIPTION
I goofed here https://github.com/parameter1/pmmi-media-group-newsletters/pull/73/commits/68d67f4faf6face5219c4a2a304bb3db82a69263 thinking this was suppose to be reducing the content rows to the placeholder ad section but it was suppose to be increasing the placeholder ad section to the width of the content rows.

<img width="1920" alt="Screen Shot 2022-04-01 at 8 33 12 AM" src="https://user-images.githubusercontent.com/46794001/161274495-03471fc0-b1e6-4c44-b19d-7c214e3116a6.png">

