### PR TITLE
Adjust row “inner-width” to 592px over 552px. New Numeric Template.

### DIFF
--- a/packages/common/components/blocks/numeric/row-five-new.marko
+++ b/packages/common/components/blocks/numeric/row-five-new.marko
@@ -44,7 +44,7 @@ $ const headlineStyle = {
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">
                         <tr>
                             <td bgcolor="#ffffff" style=borderTopStyle align="center" class="mobile-padding">
-                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 552px;">
+                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 592px;">
                                     <tr>
                                         <td style="vertical-align:top;text-align: left;" valign="top">
                                             <table border="0" cellpadding="0" cellspacing="0" width="60">

--- a/packages/common/components/blocks/numeric/row-four-new.marko
+++ b/packages/common/components/blocks/numeric/row-four-new.marko
@@ -44,7 +44,7 @@ $ const headlineStyle = {
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">
                         <tr>
                             <td bgcolor="#ffffff" style=borderTopStyle align="center" class="mobile-padding">
-                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 552px;">
+                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 592px;">
                                     <tr>
                                         <td style="vertical-align:top;text-align: left;" valign="top">
                                             <table border="0" cellpadding="0" cellspacing="0" width="60">

--- a/packages/common/components/blocks/numeric/row-one-new.marko
+++ b/packages/common/components/blocks/numeric/row-one-new.marko
@@ -44,7 +44,7 @@ $ const headlineStyle = {
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">
                         <tr>
                             <td bgcolor="#ffffff" style=borderTopStyle align="center" class="mobile-padding">
-                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 552px;">
+                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 592px;">
                                     <tr>
                                         <td style="vertical-align:top;text-align: left;" valign="top">
                                             <table border="0" cellpadding="0" cellspacing="0" width="60">

--- a/packages/common/components/blocks/numeric/row-three-new.marko
+++ b/packages/common/components/blocks/numeric/row-three-new.marko
@@ -44,7 +44,7 @@ $ const headlineStyle = {
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">
                         <tr>
                             <td bgcolor="#ffffff" style=borderTopStyle align="center" class="mobile-padding">
-                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 552px;">
+                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 592px;">
                                     <tr>
                                         <td style="vertical-align:top;text-align: left;" valign="top">
                                             <table border="0" cellpadding="0" cellspacing="0" width="60">

--- a/packages/common/components/blocks/numeric/row-two-new.marko
+++ b/packages/common/components/blocks/numeric/row-two-new.marko
@@ -44,7 +44,7 @@ $ const headlineStyle = {
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="center" class="content-table">
                         <tr>
                             <td bgcolor="#ffffff" style=borderTopStyle align="center" class="mobile-padding">
-                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 552px;">
+                                <table class="content-table" align="center" border="0" cellpadding="0" cellspacing="0" style="width: 592px;">
                                     <tr>
                                         <td style="vertical-align:top;text-align: left;" valign="top">
                                             <table border="0" cellpadding="0" cellspacing="0" width="60">


### PR DESCRIPTION
PREVIOUSLY:
<img width="1792" alt="Screen Shot 2022-04-01 at 10 09 50 AM" src="https://user-images.githubusercontent.com/46794001/161292628-87726f6f-cc27-42ac-b7f0-03438b4efd0b.png">
<img width="1791" alt="Screen Shot 2022-04-01 at 10 09 43 AM" src="https://user-images.githubusercontent.com/46794001/161292615-96dd1cd6-39b4-4fb3-bd27-0ec2de1af44f.png">


NOW:
<img width="1792" alt="Screen Shot 2022-04-01 at 10 16 45 AM" src="https://user-images.githubusercontent.com/46794001/161292704-1e595ac8-4a48-444e-9470-30b8ab1ebb48.png">
<img width="1792" alt="Screen Shot 2022-04-01 at 10 16 52 AM" src="https://user-images.githubusercontent.com/46794001/161292709-403b1416-7a60-4fcb-8ed2-bc0a4014a350.png">

