### PR TITLE
Updating headers

### DIFF
--- a/tenants/all/templates/hcp-quick-hits-new.marko
+++ b/tenants/all/templates/hcp-quick-hits-new.marko
@@ -18,10 +18,10 @@ $ const logoConfig = get(newsletterConfig, "logoConfig");
       date=date
       ...logoConfig
       image-wrapper-style={ "padding": "12px 10px 10px 10px" }
-      image-attrs={ width: 260, height: 54 }
-      image-style={ "max-width": "260px", "width": "260px", "height": "54px" }
-      image-options={ w: 260, h: 54 }
-      image-src="/files/base/pmmi/all/image/newsletters/hcp-quickhits-header-012022.png"
+      image-attrs={ width: 330, height: 54 }
+      image-style={ "max-width": "330px", "width": "330px", "height": "54px" }
+      image-options={ w: 330, h: 54 }
+      image-src="/files/base/pmmi/all/image/newsletters/hcp-quickhits-header-042022.png"
       secondary-background-color="#00c6e7"
     />
   </@header>

--- a/tenants/all/templates/pw-contract-packaging.marko
+++ b/tenants/all/templates/pw-contract-packaging.marko
@@ -25,7 +25,7 @@ $ const logoConfig = get(newsletterConfig, "logoConfig");
       image-attrs={ width: 149, height: 67 }
       image-style={ "max-width": "149px" }
       image-options={ w: 149 }
-      image-src="/files/base/pmmi/all/image/newsletters/cmp-natalie-craig-header.png"
+      image-src=""
       secondary-background-color="#008658"
     />
   </@header>


### PR DESCRIPTION
• Replaced Quick Hits image with dark mode compatible header image
• removed Natalie image link to CM+P newsletter (this should be re-filled in the near future).