### PR TITLE
Adjust body wrapper table to include footer block

### DIFF
--- a/packages/common/components/blocks/body-wrapper.marko
+++ b/packages/common/components/blocks/body-wrapper.marko
@@ -16,14 +16,14 @@ $ const { newsletter, date } = input;
       <if(input.body)>
         <${input.body} />
       </if>
+
+      <!-- Footer block -->
+      <if(input.footer)>
+        <${input.footer} />
+      </if>
+      <else>
+        <common-footer-block newsletter=newsletter date=date />
+      </else>
     </td>
   </tr>
 </table>
-
-<!-- Footer block -->
-<if(input.footer)>
-  <${input.footer} />
-</if>
-<else>
-  <common-footer-block newsletter=newsletter date=date />
-</else>


### PR DESCRIPTION
this will allow for correct responsiveness
BEFORE:
<img width="741" alt="Screen Shot 2022-06-20 at 8 01 13 AM" src="https://user-images.githubusercontent.com/64623209/174607965-cbb81d5c-1f6d-41fc-821e-11e232700b47.png">
AFTER:
<img width="761" alt="Screen Shot 2022-06-20 at 8 01 49 AM" src="https://user-images.githubusercontent.com/64623209/174607994-6e55a870-14db-44b2-b284-c929b412eaae.png">
