### PR TITLE
Adjust styling to prevent image from getting too narrow

### DIFF
--- a/tenants/all/templates/pw-shelf-impact.marko
+++ b/tenants/all/templates/pw-shelf-impact.marko
@@ -18,9 +18,9 @@ $ const logoConfig = get(newsletterConfig, "logoConfig");
       date=date
       ...logoConfig
       image-wrapper-style={ "padding": "8px 10px 6px 10px" }
-      image-attrs={ width: 275, height: 45 }
-      image-style={ "max-width": "275px" }
-      image-options={ w: 275 }
+      image-attrs={ width: 220, height: 58 }
+      image-style={ "max-width": "220px" }
+      image-options={ w: 220 }
       image-src="/files/base/pmmi/all/image/newsletters/pw-shelf-impact-header.png"
       secondary-background-color="#ee8434"
     />

--- a/tenants/mundo/templates/mundo-perspectivas.marko
+++ b/tenants/mundo/templates/mundo-perspectivas.marko
@@ -16,9 +16,9 @@ $ const { newsletter, date } = data;
       logo-options={ w: 108 }
       logo-src="/files/base/pmmi/all/image/newsletters/mundo-logo.png"
       image-wrapper-style={ "padding": "8px 10px 6px 10px" }
-      image-attrs={ width: 275, height: 45 }
-      image-style={ "max-width": "275px" }
-      image-options={ w: 275 }
+      image-attrs={ width: 220, height: 58 }
+      image-style={ "max-width": "220px" }
+      image-options={ w: 220 }
       image-src="/files/base/pmmi/all/image/newsletters/mundo-perspectivas-header.png"
       secondary-background-color= "#004261"
     />


### PR DESCRIPTION
Current:
<img width="1069" alt="Screen Shot 2023-03-20 at 2 13 55 PM" src="https://user-images.githubusercontent.com/64623209/226442884-08a1da12-0ca5-4fa6-bafc-9eccc4afe41b.png">
2 newsletters being changed:
<img width="1044" alt="Screen Shot 2023-03-20 at 2 10 18 PM" src="https://user-images.githubusercontent.com/64623209/226442889-aee7c697-115f-4013-aeb8-7e9ea8bbc436.png">
<img width="1075" alt="Screen Shot 2023-03-20 at 2 12 07 PM" src="https://user-images.githubusercontent.com/64623209/226442890-dfd75b73-c005-4840-ba56-78c8f4ea1b58.png">
