### PR TITLE
Add credspark to url match in announcement block

### DIFF
--- a/packages/common/components/blocks/standard/announcement.marko
+++ b/packages/common/components/blocks/standard/announcement.marko
@@ -23,7 +23,7 @@ $ const imgStyles = {
   "border-style": "solid",
 }
 
-$ const campaignTypeMatch = url.match(/(youtube\.com|pmmi\.dragonforms\.com)/);
+$ const campaignTypeMatch = url.match(/(youtube\.com|pmmi\.dragonforms\.com)|app.credspark.com/);
 
 $ const imgDimensions = {
   "youtube.com": { w: 100, h: 100 },


### PR DESCRIPTION
<img width="749" alt="Screen Shot 2023-07-31 at 1 25 10 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/864901e9-b0be-4a5c-85ef-b37131f300c8">
