### PR TITLE
Cpg revisions

### DIFF
--- a/packages/common/components/blocks/cpgnext/social.marko
+++ b/packages/common/components/blocks/cpgnext/social.marko
@@ -6,7 +6,7 @@
         <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
           <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
             <tr>
-              <td align="center" class="es-m-txt-c" style="padding:0;Margin:0">
+              <td align="center" class="es-m-txt-c" style="padding-top:10px;Margin:0">
                 <h1 style="Margin:0;line-height:30px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;font-size:20px;font-style:normal;font-weight:normal;color:#757575">
                   <strong>Thanks for reading <em>CPG Next.</em></strong>
                 </h1>
@@ -40,7 +40,7 @@
                       options={ w: 32 }
                       attrs={ width: 32, height: "auto", style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
                     >
-                      <@link href="https://www.linkedin.com/showcase/cpg-next/about/" target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#FD5208;font-size:14px" />
+                      <@link href="https://twitter.com/i/flow/login?redirect_after_login=%2FCPGNext" target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#FD5208;font-size:14px" />
                     </marko-newsletter-imgix>
                   </td>
                   <td align="center" valign="top" style="padding:0;Margin:0">
@@ -50,7 +50,7 @@
                       options={ w: 32 }
                       attrs={ width: 32, height: "auto", style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
                     >
-                      <@link href="https://www.linkedin.com/showcase/cpg-next/about/" target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#FD5208;font-size:14px" />
+                      <@link href="https://www.facebook.com/people/CPG-Next/100094502853092/" target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#FD5208;font-size:14px" />
                     </marko-newsletter-imgix>
                   </td>
                 </tr>

--- a/packages/common/components/blocks/cpgnext/what-we-are-reading.marko
+++ b/packages/common/components/blocks/cpgnext/what-we-are-reading.marko
@@ -57,7 +57,7 @@ $ const queryParams = {
         <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
           <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
             <tr>
-              <td align="center" style="padding-left:20px;padding-right:20px;Margin:0;font-size:0">
+              <td align="center" style="padding-left:20px;padding-right:20px;padding-bottom:10px;padding-top:10px;Margin:0;font-size:0">
                 <table border="0" width="100%" height="100%" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
                   <tr>
                     <td style="padding:0;Margin:0;border-bottom-width:1px;border-bottom-style:solid;border-bottom-color:#fd5208;background:unset;height:1px;width:100%;margin:0px"></td>

--- a/packages/common/components/layouts/cpgnext.marko
+++ b/packages/common/components/layouts/cpgnext.marko
@@ -26,7 +26,7 @@ $ const displayDate = moment(date).add(1, "days").format("dddd, MMMM DD");
     <common-cpgnext-body-wrapper-block newsletter=newsletter date=date>
       <@body>
         <html-comment> Main Body Wrapper START </html-comment>
-          <table class="es-content" cellspacing="0" cellpadding="0" align="center" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%">
+          <table class="es-content" cellspacing="0" cellpadding="0" align="center">
             <tr>
               <td align="center" style="padding:0;Margin:0">
                 <table class="es-content-body" cellspacing="0" cellpadding="0" bgcolor="#ffffff" align="center" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-color:#FFFFFF;width:600px">
@@ -200,7 +200,7 @@ $ const displayDate = moment(date).add(1, "days").format("dddd, MMMM DD");
                           <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
                             <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
                               <tr>
-                                <td align="center" style="padding-left:20px;padding-right:20px;Margin:0;font-size:0">
+                                <td align="center" style="padding-left:20px;padding-right:20px;padding-top:10px;padding-bottom:10px;Margin:0;font-size:0">
                                   <table border="0" width="100%" height="100%" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
                                     <tr>
                                       <td style="padding:0;Margin:0;border-bottom-width:1px;border-bottom-style:solid;border-bottom-color:#fd5208;background:unset;height:1px;width:100%;margin:0px"></td>


### PR DESCRIPTION
Header now stays center:
<img width="907" alt="Screen Shot 2023-10-10 at 1 05 45 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/09290c10-09fd-4767-a450-365c54cf5cd9">
Add padding above socials:
<img width="670" alt="Screen Shot 2023-10-10 at 1 11 18 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/bbccb97d-6a4c-47d0-82ca-df7b3a68c9b0">
What we're reading section now has padding:
<img width="980" alt="Screen Shot 2023-10-10 at 1 27 54 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/3e1c72dc-00c2-44fc-aa8a-d1fee9a91137">
