### PR TITLE
Make withTeaser optional for article block-CPG Next

### DIFF
--- a/packages/common/components/blocks/cpgnext/article.marko
+++ b/packages/common/components/blocks/cpgnext/article.marko
@@ -2,13 +2,14 @@ import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
 import { get, getAsArray } from "@parameter1/base-cms-object-path";
 
-$ const { newsletter, date, sectionName, withImage, id } = input;
+$ const { newsletter, date, sectionName, withImage, id, withTeaser } = input;
 
 $ const queryParams = {
   date: date.valueOf(),
   newsletterId: newsletter.id,
   sectionName,
   withImage,
+  withTeaser,
   limit: input.limit || 1,
   skip: input.skip || 0,
   queryFragment,
@@ -34,11 +35,13 @@ $ const queryParams = {
                       ${content.name}
                     </td>
                   </tr>
-                   <tr>
-                    <td align="left" class="es-m-p0l" style="padding:0;Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                      ${content.teaser}
-                    </td>
-                  </tr>
+                  <if(withTeaser === true)>
+                    <tr>
+                      <td align="left" class="es-m-p0l" style="padding:0;Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                        ${content.teaser}
+                      </td>
+                    </tr>
+                  </if>
                   <if(withImage === true)>
                     <tr>
                       <td align="center" style="padding:0;Margin:0;padding-top:20px;padding-bottom:20px;font-size:0px">

--- a/packages/common/components/layouts/cpgnext.marko
+++ b/packages/common/components/layouts/cpgnext.marko
@@ -111,6 +111,7 @@ $ const displayDate = moment(date).add(1, "days").format("dddd, MMMM DD");
                     date=date
                     section-name="Editorial Article 1"
                     withImage=true
+                    withTeaser=true
                     limit=1
                   />
                   <html-comment> Editorial Long Article 1 END </html-comment>
@@ -184,6 +185,7 @@ $ const displayDate = moment(date).add(1, "days").format("dddd, MMMM DD");
                     date=date
                     section-name="Editorial Article 2"
                     withImage=false
+                    withTeaser=false
                     limit=1
                   />
                   <html-comment> Editorial Long Article 2 END </html-comment>


### PR DESCRIPTION
DEV: (no teaser)
<img width="686" alt="Screen Shot 2023-10-11 at 2 09 38 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/fcaef23a-e4e2-46b6-a727-6a7c78eacc2c">
PROD: (with teaser)
<img width="680" alt="Screen Shot 2023-10-11 at 2 09 43 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/54116f78-0886-4070-abb8-837f1ec464a6">
DEV & PROD: (with teaser)
<img width="661" alt="Screen Shot 2023-10-11 at 2 09 33 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/e4e8aeeb-af23-4ea8-adfa-dfb0b8336809">
