### PR TITLE
Move Top announcement ad to top of cpgnext layout

### DIFF
--- a/packages/common/components/blocks/cpgnext/announcement.marko
+++ b/packages/common/components/blocks/cpgnext/announcement.marko
@@ -5,6 +5,29 @@ $ const { content } = input;
 $ const siteContext = getAsObject(content, 'siteContext');
 $ const { url } = siteContext;
 
+<html-comment> Line Divider START </html-comment>
+<tr>
+  <td class="es-m-p0r es-m-p0l" align="left" style="padding:0;Margin:0;padding-left:20px;padding-right:20px">
+    <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+      <tr>
+        <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
+          <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+            <tr>
+              <td align="center" style="padding-left:20px;padding-right:20px;Margin:0;font-size:0">
+                <table border="0" width="100%" height="100%" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                  <tr>
+                    <td style="padding-bottom:20px;Margin:0;border-bottom-width:1px;border-bottom-style:solid;border-bottom-color:#fd5208;background:unset;height:1px;width:100%;"></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+<html-comment> Line Divider END </html-comment>
 <tr>
   <td class="es-m-p20r es-m-p20l" align="left">
     <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">

--- a/packages/common/components/blocks/cpgnext/announcement.marko
+++ b/packages/common/components/blocks/cpgnext/announcement.marko
@@ -86,26 +86,3 @@ $ const { url } = siteContext;
     </table>
   </td>
 </tr>
-<html-comment> Line Divider START </html-comment>
-<tr>
-  <td class="es-m-p0r es-m-p0l" align="left" style="padding:0;Margin:0;padding-left:20px;padding-right:20px">
-    <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
-      <tr>
-        <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
-          <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
-            <tr>
-              <td align="center" style="padding-left:20px;padding-right:20px;Margin:0;font-size:0">
-                <table border="0" width="100%" height="100%" cellpadding="0" cellspacing="0" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
-                  <tr>
-                    <td style="padding:0;Margin:0;border-bottom-width:1px;border-bottom-style:solid;border-bottom-color:#fd5208;background:unset;height:1px;width:100%;"></td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </td>
-</tr>
-<html-comment> Line Divider END </html-comment>

--- a/packages/common/components/layouts/cpgnext.marko
+++ b/packages/common/components/layouts/cpgnext.marko
@@ -30,13 +30,6 @@ $ const displayDate = moment(date).add(1, "days").format("dddd, MMMM DD");
             <tr>
               <td align="center" style="padding:0;Margin:0">
                 <table class="es-content-body" cellspacing="0" cellpadding="0" bgcolor="#ffffff" align="center" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-color:#FFFFFF;width:600px">
-                  <common-cpgnext-editorial-intro-block
-                    newsletter=newsletter
-                    date=date
-                    section-name="Editorial Intro"
-                    limit=1
-                  />
-
                   <html-comment> Top Banner START </html-comment>
                   <common-cpgnext-nativex-block
                     newsletter=newsletter
@@ -45,6 +38,13 @@ $ const displayDate = moment(date).add(1, "days").format("dddd, MMMM DD");
                     with-image=true
                   />
                   <html-comment> Top Banner END </html-comment>
+
+                  <common-cpgnext-editorial-intro-block
+                    newsletter=newsletter
+                    date=date
+                    section-name="Editorial Intro"
+                    limit=1
+                  />
 
                   <common-cpgnext-edition-block
                     newsletter=newsletter


### PR DESCRIPTION
<img width="542" alt="Screen Shot 2023-12-04 at 10 18 04 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/974b2b1b-2eb7-4a86-93b6-3c002231a43b">
