### PR TITLE
Spacing adjustments, pass through primary color on native ads, update footers 2024 templates

### DIFF
--- a/packages/common/components/blocks/2024/ad/nativex.marko
+++ b/packages/common/components/blocks/2024/ad/nativex.marko
@@ -11,7 +11,7 @@ $ const placementId = get(nativeX, `placements.${newsletter.alias}.${placement}`
   <core-native-x-fetch|{ data: nxData }| uri=nativeX.uri date=date placement-id=placementId>
     <if(nxData)>
       $ const content = convertAdToContent(nxData);
-      <common-2024-promo-block content=content with-image=withImage />
+      <common-2024-promo-block content=content with-image=withImage newsletter=newsletter />
     </if>
   </core-native-x-fetch>
 </if>

--- a/packages/common/components/blocks/2024/article.marko
+++ b/packages/common/components/blocks/2024/article.marko
@@ -31,20 +31,20 @@ $ const queryParams = {
   <if(nodes.length)>
     <for|content| of=nodes>
       <tr>
-        <td align="left" style="Margin:0;padding-top:20px;padding-bottom:20px;padding-left:40px;padding-right:40px">
+        <td align="left" style="Margin:0;padding-bottom:20px;padding-left:40px;padding-right:40px">
           <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
             <tr>
               <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
                 <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
                   <tr>
-                    <td align="left" style="padding:0;Margin:0;padding-bottom:10px">
+                    <td align="left" style="padding:0;Margin:0;">
                       <p style=sectionNameStyle>
                         ${get(content, "primarySection.name")}
                       </p>
                     </td>
                   </tr>
                   <tr>
-                    <td align="left" style="padding:0;Margin:0;padding-bottom:10px">
+                    <td align="left" style="padding:0;Margin:0;">
                       <h2 style="Margin:0;line-height:27px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;font-size:18px;font-style:normal;font-weight:bold;color:#333333">
                         <a href=content.siteContext.url target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:18px;line-height:27px">
                           ${content.name}

--- a/packages/common/components/blocks/2024/body-wrapper.marko
+++ b/packages/common/components/blocks/2024/body-wrapper.marko
@@ -14,7 +14,12 @@ $ const { newsletter } = input;
   <table class="es-wrapper" width="100%" cellspacing="0" cellpadding="0" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;padding:0;Margin:0;width:100%;height:100%;background-repeat:repeat;background-position:center top;background-color:#F6F6F6">
     <tr>
       <td valign="top" style="padding:0;Margin:0">
-        <common-2024-header-block newsletter=newsletter />
+        <if(input.header)>
+          <${input.header} />
+        </if>
+        <else>
+          <common-2024-header-block newsletter=newsletter />
+        </else>
 
         <if(input.body)>
           <${input.body} />

--- a/packages/common/components/blocks/2024/divider.marko
+++ b/packages/common/components/blocks/2024/divider.marko
@@ -1,6 +1,6 @@
 <html-comment> Line Divider START </html-comment>
 <tr>
-  <td align="left" style="Margin:0;padding-top:20px;padding-bottom:20px;padding-left:40px;padding-right:40px">
+  <td align="left" style="Margin:0;padding-left:40px;padding-right:40px">
     <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
       <tr>
         <td align="center" valign="top" style="padding:0;Margin:0;width:560px">

--- a/packages/common/components/blocks/2024/events.marko
+++ b/packages/common/components/blocks/2024/events.marko
@@ -1,5 +1,6 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/website-content";
 
+$ const { header } = input;
 $ const now = Date.now();
 
 $ const queryParams = {
@@ -22,11 +23,20 @@ $ const queryParams = {
           <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
             <tr>
               <td align="left" style="padding:0;Margin:0;padding-bottom:20px;font-size:0px">
-                <marko-newsletter-imgix
-                  src='/files/base/pmmi/all/image/newsletters/upcoming-events.png'
-                  options={ h: 20 }
-                  attrs={ height: 20, style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
-                />
+                <if(header==="Mundo")>
+                  <marko-newsletter-imgix
+                    src='/files/base/pmmi/all/image/newsletters/events-mundo.png'
+                    options={ h: 20 }
+                    attrs={ height: 20, height: "auto", style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
+                  />
+                </if>
+                <else>
+                  <marko-newsletter-imgix
+                    src='/files/base/pmmi/all/image/newsletters/upcoming-events.png'
+                    options={ h: 20 }
+                    attrs={ height: 20, style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
+                  />
+                </else>
               </td>
             </tr>
             <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=queryParams>
@@ -45,7 +55,7 @@ $ const queryParams = {
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
                         <strong>
                           <a href=`${content.website}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
-                            ${content.website}
+                            ${content.name}
                           </a>
                         </strong>
                       </p>

--- a/packages/common/components/blocks/2024/footer-mundo.marko
+++ b/packages/common/components/blocks/2024/footer-mundo.marko
@@ -1,14 +1,14 @@
 <html-comment> Footer START </html-comment>
-<table cellpadding="0" cellspacing="0" class="es-footer" align="center" role="none" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%;background-color:transparent;background-repeat:repeat;background-position:center top">
+<table cellpadding="0" cellspacing="0" class="es-footer" align="center" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%;background-color:transparent;background-repeat:repeat;background-position:center top">
   <tr>
     <td align="center" style="padding:0;Margin:0">
-      <table bgcolor="#ffffff" class="es-footer-body" align="center" cellpadding="0" cellspacing="0" role="none" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-color:#FFFFFF;width:640px">
+      <table bgcolor="#ffffff" class="es-footer-body" align="center" cellpadding="0" cellspacing="0" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-color:#FFFFFF;width:640px">
         <tr>
-          <td align="left" bgcolor="#f6f6f6" style="padding:40px;Margin:0;background-color:#f6f6f6">
-            <table cellpadding="0" cellspacing="0" width="100%" role="none" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+          <td align="left" bgcolor="#f6f6f6" style="padding:35px;Margin:0;background-color:#f6f6f6">
+            <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
               <tr>
-                <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
-                  <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                <td align="center" valign="top" style="padding:0;Margin:0;width:570px">
+                  <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
                     <tr>
                       <td align="center" style="padding:0;Margin:0;font-size:0px">
                         <img src="https://scejxd.stripocdn.email/content/guids/CABINET_9a94d97c7b57a824486297873f8597b51418f52c9c225072da97efaf05d6b8cd/images/pmmimediagroup.png" alt style="display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" width="160">
@@ -16,29 +16,35 @@
                     </tr>
                     <tr>
                       <td align="center" style="padding:20px;Margin:0">
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:18px;color:#696969;font-size:12px">
                           Este correo electrónico fue enviado a @{Email Name}@ por:
                         </p>
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:18px;color:#696969;font-size:12px">
                           PMMI, Oficina en América Latina, Homero No. 418 Piso 3
                         </p>
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:18px;color:#696969;font-size:12px">
                           Col. Chapultepec Morales, Ciudad de México, México. CP 11570
                         </p>
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                          <a target="_blank" href="@{mv_online_version}@" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#333333;font-size:14px">
-                            Véalo en línea
-                          </a>
-                            &nbsp;&nbsp;|&nbsp;&nbsp;
-                          <a target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#333333;font-size:14px" href="@{confirmunsubscribelink}@">
-                            Darse de baja
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:18px;color:#666666;font-size:12px">
+                          <a target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#666666;font-size:12px" href="@{mv_online_version}@">
+                            Véalo en línea</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#666666;font-size:12px" href="@{confirmunsubscribelink}@">Darse de baja
                           </a>
                         </p>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="padding:0;Margin:0">
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#000000;font-size:14px">Este correo electrónico fue enviado por PMMI Media Group. PMMI Media Group es una división de PMMI, propietaria y productora del portafolio de ferias PACK EXPO. Al comprometerse con PMMI, usted ha dado su consentimiento para que PMMI procese y almacene su información personal con el fin de comunicarse con usted. Todas las preguntas relacionadas con las políticas, prácticas o portabilidad de privacidad de datos, así como las solicitudes para revocar el consentimiento, pueden dirigirse a <a href="mailto:dataprivacy@pmmi.org" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#000000;font-size:14px">dataprivacy@pmmi.org</a>. Cualquier contenido marcado en este correo electrónico como "presentado por", "publicado por", o "contenido de socios" está patrocinado. PMMI Media Group puede compartir su información de contacto con patrocinadores como se detalla en nuestra <a href="https://www.mundopmmi.com/page/privacidad" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#000000;font-size:14px">política de privacidad</a>, pero NUNCA compartiremos su información de contacto con un patrocinador cuyo contenido no haya visto. PMMI también puede hacer uso de sus datos para otros fines de comunicación, como para informarle sobre desarrollos, programas o publicaciones importantes de la industria.</p></td>
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:18px;color:#666666;font-size:12px">
+                          PMMI Media Group es una división de PMMI, propietario y productor de las ferias comerciales PACK EXPO. El contenido marcado en este correo electrónico como "presentado por", "llevado a usted por" o "contenido de socios" está patrocinado. PMMI Media Group puede compartir su información de contacto con patrocinadores como se detalla en nuestra <span style="color:#B22222"></span>
+                          <u>
+                            <a href="https://www.mundoexpopack.com/page/privacidad" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#666666;font-size:12px" target="_blank">
+                              política de privacidad</a></u>. Las preguntas sobre nuestras políticas de privacidad de datos pueden dirigirse a
+                            <a href="mailto:dataprivacy@pmmi.org" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#696969;font-size:12px">
+                              dataprivacy@pmmi.org
+                            </a>
+                          .
+                        </p>
+                      </td>
                     </tr>
                   </table>
                 </td>
@@ -51,6 +57,6 @@
   </tr>
 </table>
 <html-comment> Tracking Pixel START </html-comment>
-<!-- <tr><td><img src="http://dev.click.pmmimediagroup.com/tracker/pixel.gif?u=%%RECIPIENT_ID%%" alt="end" width="1" height="1" style="font-size:2px;color:#f5f5f5;display:none;"/></td></tr> -->
+<tr><td><img src="http://dev.click.pmmimediagroup.com/tracker/pixel.gif?u=%%RECIPIENT_ID%%" alt="end" width="1" height="1" style="font-size:2px;color:#f5f5f5;display:none;"/></td></tr>
 <html-comment> Tracking Pixel END </html-comment>
 <html-comment> Footer END </html-comment>

--- a/packages/common/components/blocks/2024/footer.marko
+++ b/packages/common/components/blocks/2024/footer.marko
@@ -4,51 +4,30 @@
     <td align="center" style="padding:0;Margin:0">
       <table bgcolor="#ffffff" class="es-footer-body" align="center" cellpadding="0" cellspacing="0" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;background-color:#FFFFFF;width:640px">
         <tr>
-          <td align="left" bgcolor="#f6f6f6" style="padding:40px;Margin:0;background-color:#f6f6f6">
+          <td align="left" bgcolor="#f6f6f6" style="padding:35px;Margin:0;background-color:#f6f6f6">
             <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
               <tr>
-                <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
-                  <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+                <td align="center" valign="top" style="padding:0;Margin:0;width:570px">
+                  <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
                     <tr>
                       <td align="center" style="padding:0;Margin:0;font-size:0px">
                         <img src="https://scejxd.stripocdn.email/content/guids/CABINET_9a94d97c7b57a824486297873f8597b51418f52c9c225072da97efaf05d6b8cd/images/pmmimediagroup.png" alt style="display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" width="160">
                       </td>
                     </tr>
                     <tr>
-                      <td align="center" style="padding:20px;Margin:0">
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                          This email was sent to @{Email Name}@ by:
+                      <td align="center" style="padding:0;Margin:0;padding-top:20px;padding-bottom:20px">
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:18px;color:#666666;font-size:12px">
+                          This email was sent to @{Email Name}@ by:<br>PMMI Media Group, 401 N. Michigan Ave., Suite 1700<br>Chicago, IL 60611, United States of America
                         </p>
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                          PMMI Media Group, 401 N. Michigan Avenue, Suite 1700
-                        </p>
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                          Chicago, IL 60611, United States of America
-                        </p>
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                          <a target="_blank" href="@{mv_online_version}@" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#333333;font-size:14px">
-                            View Online
-                          </a>
-                            &nbsp; | &nbsp;
-                          <a target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#333333;font-size:14px" href="@{confirmunsubscribelink}@">
-                            Unsubscribe
-                          </a>
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:18px;color:#666666;font-size:12px">
+                          <a target="_blank" href="@{mv_online_version}@" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#666666;font-size:12px">View Online</a>&nbsp;&nbsp;|&nbsp;&nbsp;<a target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#666666;font-size:12px" href="@{confirmunsubscribelink}@">Unsubscribe</a>
                         </p>
                       </td>
                     </tr>
                     <tr>
                       <td align="left" style="padding:0;Margin:0">
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                          This email was sent by PMMI Media Group. PMMI Media Group is a division of PMMI, owner and producer of the PACK EXPO portfolio of trade shows.&nbsp;By engaging with PMMI, you have provided your consent for PMMI to process and store your personal information for purposes of communicating with you. All questions regarding data privacy policies, practices, or portability, as well as requests to revoke consent can be addresse
-                          <span style="color:#000000">d to&nbsp;</span>
-                          <a href="mailto:dataprivacy@pmmi.org" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#000000;font-size:14px">
-                            dataprivacy@pmmi.org
-                          </a>
-                          <span style="color:#000000">. Any content marked in this email as ‘presented by’, ‘brought to you by’, or ‘partner content’ is sponsored. PMMI Media Group may share your contact information with sponsors as detailed in our&nbsp;
-                            <a target="_blank" href="https://www.pmmimediagroup.com/articles/privacy-policy" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#000000;font-size:14px">
-                              privacy policy
-                            </a>, but we will NEVER share your contact information with a sponsor whose content you have not viewed. PMMI
-                          </span>may also make use of your data for other communication purposes, such as to inform you of important industry developments, programs, or publications.
+                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:18px;color:#666666;font-size:12px">
+                          PMMI Media Group is a division of PMMI, owner and producer of the PACK EXPO portfolio of trade shows. Content marked in this email as ‘presented by’, ‘brought to you by’, or ‘partner content’ is sponsored. PMMI Media Group may share your contact information with sponsors as detailed in our <a target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#666666;font-size:12px" href="https://www.pmmimediagroup.com/articles/privacy-policy">privacy policy</a>. Questions regarding our data privacy policies can be addressed to <a target="_blank" href="mailto:dataprivacy@pmmi.org" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#666666;font-size:12px">dataprivacy@pmmi.org</a>.
                         </p>
                       </td>
                     </tr>
@@ -63,6 +42,6 @@
   </tr>
 </table>
 <html-comment> Tracking Pixel START </html-comment>
-<html-comment> <tr><td><img src="http://dev.click.pmmimediagroup.com/tracker/pixel.gif?u=%%RECIPIENT_ID%%" alt="end" width="1" height="1" style="font-size:2px;color:#f5f5f5;display:none;"/></td></tr> </html-comment>
+<tr><td><img src="http://dev.click.pmmimediagroup.com/tracker/pixel.gif?u=%%RECIPIENT_ID%%" alt="end" width="1" height="1" style="font-size:2px;color:#f5f5f5;display:none;"/></td></tr>
 <html-comment> Tracking Pixel END </html-comment>
 <html-comment> Footer END </html-comment>

--- a/packages/common/components/blocks/2024/footer.marko
+++ b/packages/common/components/blocks/2024/footer.marko
@@ -63,6 +63,6 @@
   </tr>
 </table>
 <html-comment> Tracking Pixel START </html-comment>
-<!-- <tr><td><img src="http://dev.click.pmmimediagroup.com/tracker/pixel.gif?u=%%RECIPIENT_ID%%" alt="end" width="1" height="1" style="font-size:2px;color:#f5f5f5;display:none;"/></td></tr> -->
+<html-comment> <tr><td><img src="http://dev.click.pmmimediagroup.com/tracker/pixel.gif?u=%%RECIPIENT_ID%%" alt="end" width="1" height="1" style="font-size:2px;color:#f5f5f5;display:none;"/></td></tr> </html-comment>
 <html-comment> Tracking Pixel END </html-comment>
 <html-comment> Footer END </html-comment>

--- a/packages/common/components/blocks/2024/header-mundo.marko
+++ b/packages/common/components/blocks/2024/header-mundo.marko
@@ -1,0 +1,40 @@
+import { get } from "@parameter1/base-cms-object-path";
+
+$ const { config } = out.global;
+$ const { newsletter } = input;
+
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const headerSrc = get(newsletterConfig, "headerSrc");
+$ const primaryColor = get(newsletterConfig, "primaryColor");
+
+<html-comment> Header START </html-comment>
+<table class="es-header" cellspacing="0" cellpadding="0" align="center" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%;background-color:transparent;background-repeat:repeat;background-position:center top">
+  <tr>
+    <td align="center" style="padding:0;Margin:0">
+      <table class="es-header-body" cellspacing="0" cellpadding="0" bgcolor=primaryColor align="center" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;width:640px">
+        <tr>
+          <td align="left" bgcolor=primaryColor style="padding:30px;Margin:0;">
+            <table width="100%" cellspacing="0" cellpadding="0" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+              <tr>
+                <td valign="top" align="center" style="padding:0;Margin:0;width:580px">
+                  <table width="100%" cellspacing="0" cellpadding="0" bgcolor=primaryColor style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;" role="presentation">
+                    <tr>
+                      <td align="center" style="padding:0;Margin:0;font-size:0px">
+                        <marko-newsletter-imgix
+                          src=headerSrc
+                          options={ w: 220 }
+                          attrs={ width: 220, height: "auto", style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
+                        />
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+<html-comment> Header END </html-comment>

--- a/packages/common/components/blocks/2024/marko.json
+++ b/packages/common/components/blocks/2024/marko.json
@@ -46,5 +46,8 @@
   },
   "<common-2024-social-mundo-block>": {
     "template": "./social-mundo.marko"
+  },
+  "<common-2024-header-mundo-block>": {
+    "template": "./header-mundo.marko"
   }
 }

--- a/packages/common/components/blocks/2024/promo.marko
+++ b/packages/common/components/blocks/2024/promo.marko
@@ -1,26 +1,45 @@
-import { getAsObject } from "@parameter1/base-cms-object-path";
+import { get, getAsObject } from "@parameter1/base-cms-object-path";
 
-$ const { content, withImage } = input;
+$ const { config } = out.global;
+$ const { newsletter, content, withImage } = input;
 
 $ const siteContext = getAsObject(content, 'siteContext');
 $ const { url } = siteContext;
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const primaryColor = get(newsletterConfig, "primaryColor");
+
+$ const contentNameStyle = {
+  "-webkit-text-size-adjust": "none",
+  "-ms-text-size-adjust": "none",
+  "mso-line-height-rule": "exactly",
+  "font-family": "arial, 'helvetica neue', helvetica, sans-serif",
+  "line-height": "21px",
+  "color": primaryColor,
+  "font-size": "14px",
+  "font-weight": "bold",
+};
+
+$ const sectionNameStyle = {
+  ...contentNameStyle,
+  "text-transform": "uppercase",
+};
 
 <if(withImage === true)>
   <tr>
-    <td class="es-m-p10b" align="left" style="Margin:0;padding-top:20px;padding-bottom:20px;padding-left:40px;padding-right:40px">
+    <td class="es-m-p10b" align="left" style="Margin:0;padding-bottom:20px;padding-left:40px;padding-right:40px">
       <!--[if mso]><table style="width:560px" cellpadding="0" cellspacing="0"><tr><td style="width:160px" valign="top"><![endif]-->
       <table class="es-left" cellspacing="0" cellpadding="0" align="left" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;float:left">
         <tr>
           <td class="es-m-p20b" align="left" style="padding:0;Margin:0;width:160px">
             <table width="100%" cellspacing="0" cellpadding="0" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;border-left:1px solid #ffffff;border-right:1px solid #ffffff;border-top:1px solid #ffffff;border-bottom:1px solid #ffffff" role="presentation">
               <tr>
-                <td align="center" style="padding:0;Margin:0;font-size:0px">
+                <td align="center" style="padding-top:20px;Margin:0;font-size:0px">
                   <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
                     <marko-newsletter-imgix
                       src=image.src
                       alt=image.alt
-                      options={ w: 158 }
-                      attrs={ width: 158, style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
+                      options={ w: 80 }
+                      attrs={ width: 80, style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
                     >
                       <@link href=url target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#005BAB;font-size:14px" />
                     </marko-newsletter-imgix>
@@ -37,18 +56,18 @@ $ const { url } = siteContext;
           <td align="left" style="padding:0;Margin:0;width:380px">
             <table width="100%" cellspacing="0" cellpadding="0" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
               <tr>
-                <td align="left" style="padding:0;Margin:0;padding-bottom:5px">
-                  <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#005bab;font-size:14px">
+                <td align="left">
+                  <p style=contentNameStyle>
                     <b>${content.name}</b>
                   </p>
                 </td>
               </tr>
               <tr>
-                <td align="left" style="padding:0;Margin:0">
+                <td align="left" style="padding-bottom:10px;Margin:0">
                   <h2 style="Margin:0;line-height:27px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;font-size:18px;font-style:normal;font-weight:bold;color:#333333">
                     <strong>
                       <a  href=url target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:18px">
-                        ${content.teaser}
+                        $!{content.teaser}
                       </a>
                     </strong>
                   </h2>
@@ -70,8 +89,8 @@ $ const { url } = siteContext;
           <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
             <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
               <tr>
-                <td align="left" style="padding:0;Margin:0;padding-bottom:10px">
-                  <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#005bab;font-size:14px">
+                <td align="left" style="padding:0;Margin:0;">
+                  <p style=sectionNameStyle>
                     <strong>${content.linkText}</strong>
                   </p>
                 </td>

--- a/packages/common/components/blocks/2024/stat.marko
+++ b/packages/common/components/blocks/2024/stat.marko
@@ -1,6 +1,6 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
 
-$ const { newsletter, date, sectionName } = input;
+$ const { newsletter, date, sectionName, header } = input;
 
 $ const queryParams = {
   sectionName,
@@ -21,12 +21,21 @@ $ const queryParams = {
               <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
                 <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
                   <tr>
-                    <td align="left" style="padding:0;Margin:0;padding-bottom:20px;font-size:0px">
-                      <marko-newsletter-imgix
-                        src='/files/base/pmmi/all/image/newsletters/stat.png'
-                        options={ h: 20 }
-                        attrs={ height: 20, height: "auto", style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
-                      />
+                    <td align="left" style="padding:0;Margin:0;font-size:0px">
+                      <if(header==="Mundo")>
+                        <marko-newsletter-imgix
+                          src='/files/base/pmmi/all/image/newsletters/stat-of-the-day-mundo.png'
+                          options={ h: 20 }
+                          attrs={ height: 20, height: "auto", style: "padding-bottom:10px;display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
+                        />
+                      </if>
+                      <else>
+                        <marko-newsletter-imgix
+                          src='/files/base/pmmi/all/image/newsletters/stat.png'
+                          options={ h: 20 }
+                          attrs={ height: 20, height: "auto", style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
+                        />
+                      </else>
                     </td>
                   </tr>
                 </table>
@@ -36,9 +45,9 @@ $ const queryParams = {
         </td>
       </tr>
       <tr>
-        <td align="left" style="Margin:0;padding-top:10px;padding-bottom:10px;padding-left:40px;padding-right:40px">
+        <td align="left" style="Margin:0;padding-bottom:10px;padding-left:40px;padding-right:40px">
           <!--[if mso]><table style="width:560px" cellpadding="0" cellspacing="0"><tr><td style="width:120px" valign="top"><![endif]-->
-          <table cellpadding="0" cellspacing="0" class="es-left" align="left" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;float:left">
+          <table cellpadding="0" cellspacing="0" class="es-left" align="left" role="none" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;float:left">
             <tr>
               <td class="es-m-p20b" align="left" style="padding:0;Margin:0;width:120px">
                 <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
@@ -50,7 +59,7 @@ $ const queryParams = {
                           alt=image.alt
                           options={ w: 120 }
                           class="adapt-img"
-                          attrs={ width: 120, style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
+                          attrs={ width: 120, style: "padding-top:20px;display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
                         />
                       </marko-core-obj-value>
                     </td>
@@ -59,8 +68,8 @@ $ const queryParams = {
               </td>
             </tr>
           </table>
-          <!--[if mso]></td><td style="width:20px"></td><td style="width:420px" valign="top"><![endif]-->
-          <table cellpadding="0" cellspacing="0" class="es-right" align="right" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;float:right">
+          <!-- [if mso]></td><td style="width:20px"></td><td style="width:420px" valign="top"><![endif] -->
+          <table cellpadding="0" cellspacing="0" class="es-right" align="right" role="none" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;float:right">
             <tr>
               <td align="left" style="padding:0;Margin:0;width:420px">
                 <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">

--- a/packages/common/components/blocks/2024/webinar.marko
+++ b/packages/common/components/blocks/2024/webinar.marko
@@ -1,6 +1,9 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/website-content";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
+$ const { header } = input;
 $ const now = Date.now();
+$ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
 
 $ const upcomingQueryParams = {
   includeContentTypes: ["Webinar"],
@@ -31,11 +34,20 @@ $ const archiveQueryParams = {
           <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
             <tr>
               <td align="left" style="padding:0;Margin:0;padding-bottom:20px;font-size:0px">
-                <marko-newsletter-imgix
-                  src='/files/base/pmmi/all/image/newsletters/webinar.png'
-                  options={ h: 20 }
-                  attrs={ height: 20, style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
-                />
+                <if(header==="Mundo")>
+                  <marko-newsletter-imgix
+                    src='/files/base/pmmi/all/image/newsletters/webinars-mundo.png'
+                    options={ h: 20 }
+                    attrs={ height: 20, height: "auto", style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
+                  />
+                </if>
+                <else>
+                  <marko-newsletter-imgix
+                    src='/files/base/pmmi/all/image/newsletters/webinar.png'
+                    options={ h: 20 }
+                    attrs={ height: 20, style: "display:block;border:0;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic" }
+                  />
+                </else>
               </td>
             </tr>
             <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=upcomingQueryParams>
@@ -68,7 +80,8 @@ $ const archiveQueryParams = {
                   <tr>
                     <td align="left" style="padding:0;Margin:0;padding-bottom:5px">
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
-                        ${content.starts}
+                        $ const start = new Date(content.startDate);
+                        ${start.toLocaleString('default', { month: 'long' })} ${start.toLocaleString('default', { day: '2-digit' })}, ${start.getFullYear()}
                       </p>
                     </td>
                   </tr>

--- a/packages/common/components/layouts/2024-mundo.marko
+++ b/packages/common/components/layouts/2024-mundo.marko
@@ -15,7 +15,7 @@ $ const emailX = config.get('emailX');
     <common-2024-head-block title=title newsletter=newsletter />
   </@head>
   <@body style="width:100%;font-family:arial, 'helvetica neue', helvetica, sans-serif;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%;padding:0;Margin:0">
-    <common-2024-body-wrapper-block newsletter=newsletter date=date footer=input.footer>
+    <common-2024-body-wrapper-block newsletter=newsletter date=date header=input.header footer=input.footer>
       <@body>
         <html-comment> Main Body Wrapper START </html-comment>
           <table class="es-content" cellspacing="0" cellpadding="0" align="center" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;table-layout:fixed !important;width:100%">
@@ -99,6 +99,7 @@ $ const emailX = config.get('emailX');
                     newsletter=newsletter
                     date=date
                     section-name="Stat"
+                    header="Mundo"
                     limit=1
                   />
                   <html-comment> Stat of the Day END </html-comment>
@@ -118,7 +119,7 @@ $ const emailX = config.get('emailX');
                   <common-2024-divider-block />
 
                   <html-comment> Upcoming Events START </html-comment>
-                  <common-2024-events-block limit=3 />
+                  <common-2024-events-block header="Mundo" limit=3 />
                   <html-comment> Upcoming Events END </html-comment>
 
                   <common-2024-divider-block />
@@ -135,7 +136,7 @@ $ const emailX = config.get('emailX');
                   <common-2024-divider-block />
 
                   <html-comment> Webinar Calendar START </html-comment>
-                  <common-2024-webinar-block />
+                  <common-2024-webinar-block header="Mundo" />
                   <html-comment> Webinar Calendar END </html-comment>
 
                   <common-2024-divider-block />

--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -197,7 +197,8 @@ const config = {
   },
   'pw-daily': {
     brand: 'Packaging World',
-    title: 'PW Daily',
+    description: 'Daily Edition',
+    title: 'PW Newsletter',
     headerSrc: '/files/base/pmmi/all/image/newsletters/pw2015_logo_white.png',
     primaryColor: '#005BAB',
     socialMedia: {
@@ -211,7 +212,7 @@ const config = {
   },
   'pfw-daily': {
     brand: 'ProFood World',
-    title: 'PFW Daily',
+    title: 'PFW Newsletter',
     headerSrc: '/files/base/pmmi/all/image/newsletters/profoodworld_logo_all_white_text.png',
     primaryColor: '#004C92',
     socialMedia: {
@@ -224,8 +225,8 @@ const config = {
     },
   },
   'oem-daily': {
-    brand: 'OEM Magazine',
-    title: 'OEM Daily',
+    brand: 'OEM Newsletter',
+    title: 'OEM Newsletter',
     headerSrc: '/files/base/pmmi/all/image/newsletters/oem_white.png',
     primaryColor: '#185B76',
     socialMedia: {
@@ -239,7 +240,7 @@ const config = {
   },
   'hcp-daily': {
     brand: 'Healthcare Packaging',
-    title: 'HCP Daily',
+    title: 'HCP Newsletter',
     headerSrc: '/files/base/pmmi/all/image/newsletters/hcp_logo_white.png',
     primaryColor: '#00B0DE',
     socialMedia: {
@@ -248,6 +249,20 @@ const config = {
         { provider: 'linkedin', href: 'https://www.linkedin.com/showcase/healthcare-packaging-/', target: '_blank' },
         { provider: 'twitter', href: 'https://twitter.com/healthcarepkg', target: '_blank' },
         { provider: 'facebook', href: 'https://www.facebook.com/HealthcarePackaging', target: '_blank' },
+      ],
+    },
+  },
+  'cmp-daily': {
+    brand: 'CM+P Newsletter',
+    title: 'CM+P Newsletter',
+    headerSrc: '/files/base/pmmi/all/image/newsletters/cmp2022_logo_white.png',
+    primaryColor: '#00B15D',
+    socialMedia: {
+      imagePath: '/files/base/pmmi/all/image/static/newsletters/',
+      links: [
+        { provider: 'linkedin', href: 'https://www.linkedin.com/showcase/packaging-world/', target: '_blank' },
+        { provider: 'twitter', href: 'https://twitter.com/packagingworld', target: '_blank' },
+        { provider: 'facebook', href: 'https://www.facebook.com/PackagingWorld/', target: '_blank' },
       ],
     },
   },

--- a/tenants/all/config/email-x.js
+++ b/tenants/all/config/email-x.js
@@ -290,6 +290,14 @@ config
       width: 560,
       height: 127,
     },
+  ])
+  .setAdUnits('cmp-daily', [
+    {
+      name: 'bottom-audience-banner',
+      id: '65776e28fb8ee314971d203b',
+      width: 560,
+      height: 127,
+    },
   ]);
 
 module.exports = config;

--- a/tenants/all/config/native-x.js
+++ b/tenants/all/config/native-x.js
@@ -265,5 +265,9 @@ module.exports = {
     cpgnext: {
       'top-banner': '65157090f4a4a50001c2027c',
     },
+    'cmp-daily': {
+      subscription: '65776e85f2eda200019152ec',
+      promotion: '65776e90e9037c00019bb649',
+    },
   },
 };

--- a/tenants/all/templates/cmp-daily.marko
+++ b/tenants/all/templates/cmp-daily.marko
@@ -1,0 +1,1 @@
+<common-2024-daily-layout data=data />

--- a/tenants/mundo/config/core.js
+++ b/tenants/mundo/config/core.js
@@ -18,7 +18,7 @@ const config = {
   },
   'mundo-expo-pack': {
     brand: 'Mundo EXPO PACK',
-    title: 'OEM Daily',
+    title: 'Mundo EXPO PACK',
     lang: 'es',
     headerSrc: '/files/base/pmmi/all/image/newsletters/mundo_expo_pack_revwhite.png',
     primaryColor: '#007557',

--- a/tenants/mundo/templates/mundo-expo-pack.marko
+++ b/tenants/mundo/templates/mundo-expo-pack.marko
@@ -3,6 +3,9 @@ $ const { newsletter, date } = data;
 <common-2024-mundo-layout
   data=data
 >
+  <@header>
+    <common-2024-header-mundo-block date=date newsletter=newsletter />
+  </@header>
   <@footer>
     <common-2024-footer-mundo-block date=date newsletter=newsletter />
   </@footer>


### PR DESCRIPTION
<img width="675" alt="Screen Shot 2023-12-12 at 11 35 33 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/cf4dc367-d3ac-46ac-be61-117cfc483369">
<img width="652" alt="Screen Shot 2023-12-12 at 11 34 53 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/ce2f9360-8169-44b5-a754-eaa79ecc042f">
<img width="714" alt="Screen Shot 2023-12-12 at 11 34 44 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/18f7c8bb-60a4-4c2f-987d-2ab5fc422869">
<img width="664" alt="Screen Shot 2023-12-12 at 11 34 29 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/d400935e-608c-4955-ad0f-c3e27fc28b14">
