### PR TITLE
Adjust padding ‘editor’s note’ and promo block

### DIFF
--- a/packages/common/components/blocks/2024-head.marko
+++ b/packages/common/components/blocks/2024-head.marko
@@ -158,6 +158,7 @@ $ const title = get(newsletterConfig, "title");
       .es-m-p40r { padding-right:40px!important }
       .es-m-p40l { padding-left:40px!important }
       .hide-mobile { padding: 0px!important }
+      .mobile-padding { padding-top: 20px !important; padding-bottom: 20px !important}
     }
   </style>
  </head>

--- a/packages/common/components/blocks/2024/editors-note.marko
+++ b/packages/common/components/blocks/2024/editors-note.marko
@@ -37,10 +37,8 @@ $ const queryParams = {
                     </td>
                   </tr>
                   <tr>
-                    <td align="left" style="padding:0;Margin:0">
-                      <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                        $!{content.body}
-                      </p>
+                    <td align="left" style="padding:0;Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                      $!{content.body}
                     </td>
                   </tr>
                 </table>

--- a/packages/common/components/blocks/2024/promo.marko
+++ b/packages/common/components/blocks/2024/promo.marko
@@ -39,7 +39,7 @@ $ const imgOptions =  {
 
 <if(withImage === true)>
   <tr>
-    <td class="es-m-p0t es-m-p0b" align="left" style="Margin:0;padding-top:20px;padding-bottom:20px;padding-left:40px;padding-right:40px">
+    <td class="es-m-p0t es-m-p0b mobile-padding" align="left" style="Margin:0;padding-top:20px;padding-bottom:20px;padding-left:40px;padding-right:40px">
       <!--[if mso]><table style="width:560px" cellpadding="0" cellspacing="0"><tr><td style="width:96px" valign="top"><![endif]-->
       <table class="es-left" cellspacing="0" cellpadding="0" align="left" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;float:left">
         <tr>


### PR DESCRIPTION
<img width="695" alt="Screen Shot 2023-12-21 at 3 31 22 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/3f38cdb5-2a56-45c2-914f-cc8f1302ee20">
