### PR TITLE
Add Url params on Event and Webinar blocks

### DIFF
--- a/packages/common/components/blocks/2024/events-mundo.marko
+++ b/packages/common/components/blocks/2024/events-mundo.marko
@@ -1,6 +1,11 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/website-content";
 
+$ const { config } = out.global;
+$ const { newsletter } = input;
 $ const now = Date.now();
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const brand = get(newsletterConfig, "brand");
 
 $ const queryParams = {
   limit: input.limit || 1,
@@ -44,7 +49,7 @@ $ const queryParams = {
                     <td align="left" style="padding:0;Margin:0;padding-bottom:20px">
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
                         <strong>
-                          <a href=`${content.website}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                          <a href=`${content.website}?ref=${brand}=news` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
                             ${content.name}
                           </a>
                         </strong>

--- a/packages/common/components/blocks/2024/events.marko
+++ b/packages/common/components/blocks/2024/events.marko
@@ -1,7 +1,11 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/website-content";
 
-$ const { header } = input;
+$ const { config } = out.global;
+$ const { header, newsletter } = input;
 $ const now = Date.now();
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const brand = get(newsletterConfig, "brand");
 
 $ const queryParams = {
   limit: input.limit || 1,
@@ -14,6 +18,7 @@ $ const queryParams = {
     order: "asc",
   },
 };
+
 
 <tr>
   <td align="left" style="Margin:0;padding-bottom:10px;padding-top:20px;padding-left:40px;padding-right:40px">
@@ -45,7 +50,7 @@ $ const queryParams = {
                     <td align="left" style="padding:0;Margin:0;padding-bottom:20px">
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
                         <strong>
-                          <a href=`${content.website}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                          <a href=`${content.website}?ref=${brand}=news` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
                             ${content.name}
                           </a>
                         </strong>

--- a/packages/common/components/blocks/2024/webinar.marko
+++ b/packages/common/components/blocks/2024/webinar.marko
@@ -1,9 +1,13 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/website-content";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
-$ const { header } = input;
+$ const { config } = out.global;
+$ const { header, newsletter } = input;
 $ const now = Date.now();
 $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const brand = get(newsletterConfig, "brand");
 
 $ const upcomingQueryParams = {
   includeContentTypes: ["Webinar"],
@@ -64,7 +68,7 @@ $ const archiveQueryParams = {
                     <td align="left" style="padding:0;Margin:0;padding-bottom:20px">
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
                         <strong>
-                          <a href=`${content.linkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                          <a href=`${content.linkUrl}?ref=${brand}=news` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
                             ${content.name}
                           </a>
                         </strong>
@@ -95,7 +99,7 @@ $ const archiveQueryParams = {
                     <td align="left" style="padding:0;Margin:0;padding-bottom:20px">
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
                         <strong>
-                          <a href=`${content.linkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                          <a href=`${content.linkUrl}?ref=${brand}=news` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
                             ${content.name}
                           </a>
                         </strong>

--- a/packages/common/components/layouts/2024-daily.marko
+++ b/packages/common/components/layouts/2024-daily.marko
@@ -163,7 +163,10 @@ $ const emailX = config.get('emailX');
                   <common-2024-divider-block />
 
                   <html-comment> Upcoming Events START </html-comment>
-                  <common-2024-events-block limit=3 />
+                  <common-2024-events-block
+                    newsletter=newsletter
+                    limit=3
+                  />
                   <html-comment> Upcoming Events END </html-comment>
 
                   <common-2024-divider-block />
@@ -180,7 +183,7 @@ $ const emailX = config.get('emailX');
                   <common-2024-divider-block />
 
                   <html-comment> Webinar Calendar START </html-comment>
-                  <common-2024-webinar-block />
+                  <common-2024-webinar-block newsletter=newsletter />
                   <html-comment> Webinar Calendar END </html-comment>
 
                   <common-2024-divider-block />

--- a/packages/common/components/layouts/2024-mundo.marko
+++ b/packages/common/components/layouts/2024-mundo.marko
@@ -139,7 +139,11 @@ $ const emailX = config.get('emailX');
                   <common-2024-divider-block />
 
                   <html-comment> Upcoming Events START </html-comment>
-                  <common-2024-events-mundo-block newsletter=newsletter date=date limit=3 />
+                  <common-2024-events-mundo-block
+                    newsletter=newsletter
+                    date=date
+                    limit=3
+                  />
                   <html-comment> Upcoming Events END </html-comment>
 
                   <common-2024-divider-block />
@@ -156,7 +160,10 @@ $ const emailX = config.get('emailX');
                   <common-2024-divider-block />
 
                   <html-comment> Webinar Calendar START </html-comment>
-                  <common-2024-webinar-block header="Mundo" />
+                  <common-2024-webinar-block
+                    newsletter=newsletter
+                    header="Mundo"
+                  />
                   <html-comment> Webinar Calendar END </html-comment>
 
                   <common-2024-divider-block />


### PR DESCRIPTION
<img width="982" alt="Screen Shot 2024-01-04 at 7 22 35 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/d9ebb136-dd45-48f1-ad90-c3022da95b08">
<img width="873" alt="Screen Shot 2024-01-04 at 7 29 27 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/aae56fe8-31e6-4fb8-8881-6080ae9544e6">
<img width="917" alt="Screen Shot 2024-01-04 at 7 31 41 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/880466cf-813f-4f71-9e16-ba0daec1cd20">
