### PR TITLE
Add brandShort for mundo expo pack

### DIFF
--- a/tenants/mundo/config/core.js
+++ b/tenants/mundo/config/core.js
@@ -18,6 +18,7 @@ const config = {
   },
   'mundo-expo-pack': {
     brand: 'Mundo EXPO PACK',
+    brandShort: 'mundo',
     title: 'Mundo EXPO PACK',
     lang: 'es',
     headerSrc: '/files/base/pmmi/all/image/newsletters/mundo_expo_pack_revwhite.png',


### PR DESCRIPTION
This passes through url params for events and webinars:
<img width="999" alt="Screen Shot 2024-01-09 at 1 44 22 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/e60fe690-bca2-4791-84b7-7cd005202da1">
