### PR TITLE
Add url params to Events block on CPGNext layout

### DIFF
--- a/packages/common/components/blocks/cpgnext/event.marko
+++ b/packages/common/components/blocks/cpgnext/event.marko
@@ -1,6 +1,11 @@
+import { get } from "@parameter1/base-cms-object-path";
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/website-content";
 
+$ const { config } = out.global;
+$ const { header, newsletter } = input;
 $ const now = Date.now();
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const brandShort = get(newsletterConfig, "brandShort");
 
 $ const upcomingQueryParams = {
   includeContentTypes: ["Event"],
@@ -16,6 +21,9 @@ $ const upcomingQueryParams = {
 <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=upcomingQueryParams>
   <if(nodes.length)>
     <for|content| of=nodes>
+      $ const contentWebsiteUrl = new URL(content.website);
+      $ const { searchParams } = contentWebsiteUrl
+      $ searchParams.set('ref', `${brandShort}-news`);
       <html-comment> Line Divider START </html-comment>
       <tr>
         <td class="es-m-p0" align="left" style="padding:20px;Margin:0">
@@ -64,7 +72,7 @@ $ const upcomingQueryParams = {
                     <td align="center" class="es-m-txt-c" style="padding:0;Margin:0;padding-bottom:5px">
                       <h2 style="Margin:0;line-height:27px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;font-size:18px;font-style:normal;font-weight:normal;color:#fd5208">
                         <strong>
-                          <a href=`${content.linkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#FD5208;font-size:18px;line-height:27px">
+                          <a href=`${contentWebsiteUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#FD5208;font-size:18px;line-height:27px">
                             ${content.name}
                           </a>
                         </strong>

--- a/packages/common/components/layouts/cpgnext.marko
+++ b/packages/common/components/layouts/cpgnext.marko
@@ -200,7 +200,7 @@ $ const displayDate = moment(date).add(1, "days").format("dddd, MMMM DD");
                   <html-comment> Editorial Long Article 2 END </html-comment>
 
                   <html-comment> Event START </html-comment>
-                  <common-cpgnext-event-block />
+                  <common-cpgnext-event-block newsletter=newsletter />
                   <html-comment> Event END </html-comment>
 
                   <html-comment> Line Divider START </html-comment>

--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -30,6 +30,7 @@ const config = {
   },
   cpgnext: {
     name: 'CPGNext',
+    brandShort: 'cpgnext',
     description: 'Digital Transformation In Packaged Goods Manufacturing',
   },
   'pw-weekly': {


### PR DESCRIPTION
<img width="458" alt="Screen Shot 2024-01-10 at 8 17 22 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/126d9610-dfbc-4a6f-9142-b714b349cad4">
<img width="1479" alt="Screen Shot 2024-01-10 at 8 17 16 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/a639908b-beb0-4454-af92-bbd1e9f7552f">
