### PR TITLE
Remove space between text and period in footer text

### DIFF
--- a/packages/common/components/blocks/2024/footer-mundo.marko
+++ b/packages/common/components/blocks/2024/footer-mundo.marko
@@ -41,8 +41,7 @@
                               política de privacidad</a></u>. Las preguntas sobre nuestras políticas de privacidad de datos pueden dirigirse a
                             <a href="mailto:dataprivacy@pmmi.org" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#696969;font-size:12px">
                               dataprivacy@pmmi.org
-                            </a>
-                          .
+                            </a>.
                         </p>
                       </td>
                     </tr>


### PR DESCRIPTION
<img width="423" alt="Screen Shot 2024-01-15 at 7 00 03 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/4ba2c394-371f-48fe-9149-5681bbebb605">
