### PR TITLE
Create Mundo Webinar block to account for Spanish date format

### DIFF
--- a/packages/common/components/blocks/2024/marko.json
+++ b/packages/common/components/blocks/2024/marko.json
@@ -58,5 +58,8 @@
   },
   "<common-2024-download-block>": {
     "template": "./download.marko"
+  },
+  "<common-2024-webinar-mundo-block>": {
+    "template": "./webinar-mundo.marko"
   }
 }

--- a/packages/common/components/blocks/2024/webinar-mundo.marko
+++ b/packages/common/components/blocks/2024/webinar-mundo.marko
@@ -3,7 +3,7 @@ import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/we
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { config } = out.global;
-$ const { header, newsletter } = input;
+$ const { newsletter } = input;
 $ const now = Date.now();
 $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
 $ const newsletterConfig = config.get(newsletter.alias);

--- a/packages/common/components/blocks/2024/webinar-mundo.marko
+++ b/packages/common/components/blocks/2024/webinar-mundo.marko
@@ -1,0 +1,106 @@
+import { get } from "@parameter1/base-cms-object-path";
+import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/website-content";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+
+$ const { config } = out.global;
+$ const { header, newsletter } = input;
+$ const now = Date.now();
+$ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const brandShort = get(newsletterConfig, "brandShort");
+
+$ const upcomingQueryParams = {
+  includeContentTypes: ["Webinar"],
+  queryFragment,
+  beginningAfter: now,
+  limit: 2,
+  sort: {
+    field: "startDate",
+    order: "asc",
+  },
+};
+$ const archiveQueryParams = {
+  includeContentTypes: ["Webinar"],
+  queryFragment,
+  beginningBefore: now,
+  sort: {
+    field: "startDate",
+    order: "desc",
+  },
+  limit: 1,
+};
+
+<tr>
+  <td align="left" style="Margin:0;padding-bottom:10px;padding-top:20px;padding-left:40px;padding-right:40px">
+    <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+      <tr>
+        <td align="center" valign="top" style="padding:0;Margin:0;width:560px">
+          <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
+            <tr>
+              <td align="left" style="padding:0;Margin:0;padding-bottom:20px;font-size:0px">
+                <marko-newsletter-imgix
+                  src='/files/base/pmmi/all/image/newsletters/webinars-mundo.png'
+                />
+              </td>
+            </tr>
+            <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=upcomingQueryParams>
+              <if(nodes.length)>
+                <for|content| of=nodes>
+                  $ const contentLinkUrl = new URL(content.linkUrl);
+                  $ const { searchParams } = contentLinkUrl
+                  $ searchParams.set('ref', `${brandShort}-news`);
+                  <tr>
+                    <td align="left" style="padding:0;Margin:0;padding-bottom:5px">
+                      $ const start = new Date(content.startDate);
+                      <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
+                        ${start.toLocaleString('es-MX', { day: '2-digit' })} ${start.toLocaleString('es-MX', { month: 'long' })} ${start.getFullYear()} | ${content.starts}
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td align="left" style="padding:0;Margin:0;padding-bottom:20px">
+                      <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                        <strong>
+                          <a href=`${contentLinkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                            ${content.name}
+                          </a>
+                        </strong>
+                      </p>
+                    </td>
+                  </tr>
+                </for>
+              </if>
+            </marko-web-query>
+            <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=archiveQueryParams>
+              <if(nodes.length)>
+                <for|content| of=nodes>
+                  $ const contentLinkUrl = new URL(content.linkUrl);
+                  $ const { searchParams } = contentLinkUrl
+                  $ searchParams.set('ref', `${brandShort}-news`);
+                  <tr>
+                    <td align="left" style="padding:0;Margin:0;padding-bottom:5px">
+                      <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
+                        Disponible ahora bajo demanda
+                      </p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td align="left" style="padding:0;Margin:0;padding-bottom:20px">
+                      <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                        <strong>
+                          <a href=`${contentLinkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                            ${content.name}
+                          </a>
+                        </strong>
+                      </p>
+                    </td>
+                  </tr>
+                </for>
+              </if>
+            </marko-web-query>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/packages/common/components/blocks/2024/webinar.marko
+++ b/packages/common/components/blocks/2024/webinar.marko
@@ -3,7 +3,7 @@ import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/we
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 
 $ const { config } = out.global;
-$ const { header, newsletter } = input;
+$ const { newsletter } = input;
 $ const now = Date.now();
 $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
 $ const newsletterConfig = config.get(newsletter.alias);

--- a/packages/common/components/blocks/2024/webinar.marko
+++ b/packages/common/components/blocks/2024/webinar.marko
@@ -38,16 +38,9 @@ $ const archiveQueryParams = {
           <table cellpadding="0" cellspacing="0" width="100%" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
             <tr>
               <td align="left" style="padding:0;Margin:0;padding-bottom:20px;font-size:0px">
-                <if(header==="Mundo")>
-                  <marko-newsletter-imgix
-                    src='/files/base/pmmi/all/image/newsletters/webinars-mundo.png'
-                  />
-                </if>
-                <else>
-                  <marko-newsletter-imgix
-                    src='/files/base/pmmi/all/image/newsletters/webinar.png'
-                  />
-                </else>
+                <marko-newsletter-imgix
+                  src='/files/base/pmmi/all/image/newsletters/webinar.png'
+                />
               </td>
             </tr>
             <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=upcomingQueryParams>
@@ -58,8 +51,9 @@ $ const archiveQueryParams = {
                   $ searchParams.set('ref', `${brandShort}-news`);
                   <tr>
                     <td align="left" style="padding:0;Margin:0;padding-bottom:5px">
+                      $ const start = new Date(content.startDate);
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
-                        ${content.starts}
+                        ${start.toLocaleString('en-US', { month: 'long' })} ${start.toLocaleString('en-US', { day: '2-digit' })}, ${start.getFullYear()} | ${content.starts}
                       </p>
                     </td>
                   </tr>
@@ -85,16 +79,9 @@ $ const archiveQueryParams = {
                   $ searchParams.set('ref', `${brandShort}-news`);
                   <tr>
                     <td align="left" style="padding:0;Margin:0;padding-bottom:5px">
-                      <if(header==="Mundo")>
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
-                          Disponible ahora bajo demanda
-                        </p>
-                      </if>
-                      <else>
-                        <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
-                          Now Available On-Demand
-                        </p>
-                      </else>
+                      <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
+                        Now Available On-Demand
+                      </p>
                     </td>
                   </tr>
                   <tr>

--- a/packages/common/components/layouts/2024-mundo.marko
+++ b/packages/common/components/layouts/2024-mundo.marko
@@ -160,9 +160,8 @@ $ const emailX = config.get('emailX');
                   <common-2024-divider-block />
 
                   <html-comment> Webinar Calendar START </html-comment>
-                  <common-2024-webinar-block
+                  <common-2024-webinar-mundo-block
                     newsletter=newsletter
-                    header="Mundo"
                   />
                   <html-comment> Webinar Calendar END </html-comment>
 

--- a/packages/common/graphql/fragments/website-content.js
+++ b/packages/common/graphql/fragments/website-content.js
@@ -44,7 +44,7 @@ fragment WebsiteContentListFragment on Content {
   ... on ContentWebinar {
     name(input: { mutation: Email })
     linkUrl
-    starts(input:{ format: "MMMM D, YYYY | h:mma z" })
+    starts(input:{ format: "h:mma z" })
     startDate
   }
 }


### PR DESCRIPTION
<img width="532" alt="Screen Shot 2024-01-17 at 10 37 51 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/098c76e4-007e-4e86-a73d-17ac2ffc560c">
<img width="534" alt="Screen Shot 2024-01-17 at 10 38 03 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/647b2ef5-0256-4703-acee-81edf2c59156">
