### PR TITLE
Use numeric for end date format on events

### DIFF
--- a/packages/common/components/blocks/2024/events.marko
+++ b/packages/common/components/blocks/2024/events.marko
@@ -43,7 +43,12 @@ $ const queryParams = {
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
                         $ const start = new Date(content.startDate);
                         $ const end = new Date(content.endDate);
-                        ${start.toLocaleString('default', { month: 'long' })} ${start.toLocaleString('default', { day: 'numeric' })}&ndash;${end.toLocaleString('default', { day: 'numeric' })}, ${start.getFullYear()} | ${content.city}, ${content.state}
+                        <if(start.getMonth() === end.getMonth())>
+                          ${start.toLocaleString('default', { month: 'long' })} ${start.toLocaleString('default', { day: 'numeric' })}&ndash;${end.toLocaleString('default', { day: 'numeric' })}, ${start.getFullYear()} | ${content.city}, ${content.state}
+                        </if>
+                        <else>
+                          ${start.toLocaleString('default', { month: 'long' })} ${start.toLocaleString('default', { day: 'numeric' })}&ndash;${end.toLocaleString('default', { month: 'long' })} ${end.toLocaleString('default', { day: 'numeric' })}, ${start.getFullYear()} | ${content.city}, ${content.state}
+                        </else>
                       </p>
                     </td>
                   </tr>

--- a/packages/common/components/blocks/2024/events.marko
+++ b/packages/common/components/blocks/2024/events.marko
@@ -43,7 +43,7 @@ $ const queryParams = {
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
                         $ const start = new Date(content.startDate);
                         $ const end = new Date(content.endDate);
-                        ${start.toLocaleString('default', { month: 'long' })} ${start.toLocaleString('default', { day: 'numeric' })}&ndash;${end.toLocaleString('default', { day: '2-digit' })}, ${start.getFullYear()} | ${content.city}, ${content.state}
+                        ${start.toLocaleString('default', { month: 'long' })} ${start.toLocaleString('default', { day: 'numeric' })}&ndash;${end.toLocaleString('default', { day: 'numeric' })}, ${start.getFullYear()} | ${content.city}, ${content.state}
                       </p>
                     </td>
                   </tr>


### PR DESCRIPTION
Missed here: https://github.com/parameter1/pmmi-media-group-newsletters/pull/152/files#diff-eac3d3be26d9a252e1e0d6655594b5123d37257d28657babdc1f76fa5bbb15b2R46