### PR TITLE
Add padding between events-CPGNext layout

### DIFF
--- a/packages/common/components/blocks/cpgnext/event.marko
+++ b/packages/common/components/blocks/cpgnext/event.marko
@@ -83,7 +83,7 @@ $ const upcomingQueryParams = {
                     </td>
                   </tr>
                   <tr>
-                    <td align="center" class="es-m-txt-c" style="padding:0;Margin:0">
+                    <td align="center" class="es-m-txt-c" style="padding-bottom:5px;Margin:0">
                       <p style="Margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
                         $ const start = new Date(content.startDate);
                         $ const end = new Date(content.endDate);


### PR DESCRIPTION
<img width="644" alt="Screen Shot 2024-01-22 at 1 58 30 PM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/b0d0c487-2dfc-4935-a4aa-22c35831466c">
