### PR TITLE
Render ProSource content with appropriate link and "eyebrow"

### DIFF
--- a/packages/common/components/blocks/2024/article.marko
+++ b/packages/common/components/blocks/2024/article.marko
@@ -31,6 +31,7 @@ $ const queryParams = {
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
   <if(nodes.length)>
     <for|content| of=nodes>
+      $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
       <tr>
         <td align="left" style="Margin:0;padding-bottom:20px;padding-left:40px;padding-right:40px">
           <table cellpadding="0" cellspacing="0" width="100%" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
@@ -40,14 +41,20 @@ $ const queryParams = {
                   <tr>
                     <td align="left" style="padding:0;Margin:0;">
                       <p style=sectionNameStyle>
-                        ${get(content, "primarySection.name")}
+                        <if(primarySiteIsProSource)>
+                          ${get(content, "prosourcePrimarySection.name")}
+                        </if>
+                        <else>
+                          ${get(content, "primarySection.name")}
+                        </else>
                       </p>
                     </td>
                   </tr>
                   <tr>
                     <td align="left" style="padding:0;Margin:0;">
                       <h2 style="Margin:0;line-height:27px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;font-size:18px;font-style:normal;font-weight:bold;color:#333333">
-                        <a href=content.siteContext.url target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:18px;line-height:27px">
+                        $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
+                        <a href=contentLink target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:18px;line-height:27px">
                           ${content.name}
                         </a>
                       </h2>

--- a/packages/common/components/blocks/expo/content-list-item.marko
+++ b/packages/common/components/blocks/expo/content-list-item.marko
@@ -1,10 +1,12 @@
 import { get, getAsArray } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
-import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
 
 $ const { newsletter, date, content, sectionName } = input;
 
 $ const withImage = defaultValue(input.withImage, false);
+$ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+$ const contentPrimarySectionName = primarySiteIsProSource ? get(content, "prosourcePrimarySection.name") : get(content, "primarySection.name")
+$ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
 
 $ const imgStyles = {
   "display": "block",
@@ -40,7 +42,7 @@ $ const imgStyles = {
                               class="img-max"
                               attrs={ style: imgStyles, border: 0 }
                             >
-                              <@link href=content.siteContext.url target="_blank" />
+                              <@link href=contentLink target="_blank" />
                             </marko-newsletter-imgix>
                           </marko-core-obj-value>
                         </td>
@@ -56,12 +58,12 @@ $ const imgStyles = {
                           <table border="0" cellpadding="0" cellspacing="0" width="100%">
                             <tr>
                               <td style="color: #b8b8b8; font-family: Helvetica, Arial, sans-serif; font-size: 12px;text-transform:uppercase;letter-spacing: .5px;font-weight: bold; padding: 0 0 8px 0;" align="left">
-                                ${get(content, "primarySection.name")}
+                                ${contentPrimarySectionName}
                               </td>
                             </tr>
                             <tr>
                               <td style="padding: 0 0 12px 0; color: #3a3636; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 24px;">
-                                <a href=content.siteContext.url target="_blank" style="color: #3a3636; text-decoration: none;">
+                                <a href=contentLink target="_blank" style="color: #3a3636; text-decoration: none;">
                                   ${content.name}
                                 </a>
                               </td>

--- a/packages/common/components/blocks/expo/main-video.marko
+++ b/packages/common/components/blocks/expo/main-video.marko
@@ -43,6 +43,8 @@ $ const imgStyles = {
                           <table border="0" cellpadding="0" cellspacing="0" width="100%" align="left">
                             <tr>
                               <td style="padding-right:16px;" class="mobilepadding-rt" valign="top">
+                                $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                                $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                                 <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
                                   <marko-newsletter-imgix
                                     src=image.src
@@ -51,7 +53,7 @@ $ const imgStyles = {
                                     class="img-max"
                                     attrs={ style: imgStyles, border: 0 }
                                   >
-                                    <@link href=content.siteContext.url target="_blank" />
+                                    <@link href=contentLink target="_blank" />
                                   </marko-newsletter-imgix>
                                 </marko-core-obj-value>
                               </td>

--- a/packages/common/components/blocks/expo/video-list-item.marko
+++ b/packages/common/components/blocks/expo/video-list-item.marko
@@ -29,6 +29,8 @@ $ const imgStyles = {
                     <table border="0" cellpadding="0" cellspacing="0" width="100%" align="left">
                       <tr>
                         <td style="padding-right:16px;" class="mobilepadding-rt" valign="top">
+                          $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                          $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                           <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
                             <marko-newsletter-imgix
                               src=image.src
@@ -37,7 +39,7 @@ $ const imgStyles = {
                               class="img-max"
                               attrs={ style: imgStyles, border: 0 }
                             >
-                              <@link href=content.siteContext.url target="_blank" />
+                              <@link href=contentLink target="_blank" />
                             </marko-newsletter-imgix>
                           </marko-core-obj-value>
                         </td>

--- a/packages/common/components/blocks/numeric/row-five-new.marko
+++ b/packages/common/components/blocks/numeric/row-five-new.marko
@@ -1,4 +1,5 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date, imagePath, colors } = input;
 

--- a/packages/common/components/blocks/numeric/row-five-new.marko
+++ b/packages/common/components/blocks/numeric/row-five-new.marko
@@ -58,6 +58,8 @@ $ const headlineStyle = {
                                         </td>
                                     </tr>
                                     $ const content = nodes[0];
+                                    $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                                    $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                                     <tr>
                                         <td dir="rtl" width="100%" style="padding: 24px 0 0 0;direction:rtl;" align="center" valign="top">
                                             <!-- Two column -->
@@ -79,7 +81,7 @@ $ const headlineStyle = {
                                                                                             class="img-max"
                                                                                             attrs={ style: imgStyles }
                                                                                             >
-                                                                                            <@link href=content.siteContext.url target="_blank" />
+                                                                                            <@link href=contentLink target="_blank" />
                                                                                             </marko-newsletter-imgix>
                                                                                         </marko-core-obj-value>
                                                                                 </td>
@@ -98,7 +100,7 @@ $ const headlineStyle = {
                                                                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                                                             <tr>
                                                                                 <td style="padding: 0 0 8px 0; color: #3c3c3c; font-family: Helvetica, Arial, sans-serif; font-size: 20px; font-weight: bold; line-height: 30px;" align="left" class="mobileheader">
-                                                                                    <a href=content.siteContext.url target="_blank" style=headlineStyle>${content.name}</a>
+                                                                                    <a href=contentLink target="_blank" style=headlineStyle>${content.name}</a>
                                                                                 </td>
                                                                             </tr>
                                                                             <tr>
@@ -108,7 +110,7 @@ $ const headlineStyle = {
                                                                             </tr>
                                                                             <tr>
                                                                                 <td style="color: #555555; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 24px; padding: 0 0 12px 0;" align="left" class="body-text">
-                                                                                    <a href=content.siteContext.url target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
+                                                                                    <a href=contentLink target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
                                                                                 </td>
                                                                             </tr>
                                                                         </table>

--- a/packages/common/components/blocks/numeric/row-four-new.marko
+++ b/packages/common/components/blocks/numeric/row-four-new.marko
@@ -1,4 +1,5 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date, imagePath, colors } = input;
 

--- a/packages/common/components/blocks/numeric/row-four-new.marko
+++ b/packages/common/components/blocks/numeric/row-four-new.marko
@@ -58,6 +58,8 @@ $ const headlineStyle = {
                                         </td>
                                     </tr>
                                     $ const content = nodes[0];
+                                    $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                                    $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                                     <tr>
                                         <td dir="rtl" width="100%" style="padding: 24px 0 0 0;direction:rtl;" align="center" valign="top">
                                             <!-- Two column -->
@@ -79,7 +81,7 @@ $ const headlineStyle = {
                                                                                         class="img-max"
                                                                                         attrs={ style: imgStyles }
                                                                                         >
-                                                                                        <@link href=content.siteContext.url target="_blank" />
+                                                                                        <@link href=contentLink target="_blank" />
                                                                                         </marko-newsletter-imgix>
                                                                                     </marko-core-obj-value>
                                                                             </td>
@@ -98,7 +100,7 @@ $ const headlineStyle = {
                                                                     <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                                                         <tr>
                                                                             <td style="padding: 0 0 8px 0; color: #3c3c3c; font-family: Helvetica, Arial, sans-serif; font-size: 20px; font-weight: bold; line-height: 30px;" align="left" class="mobileheader">
-                                                                                <a href=content.siteContext.url target="_blank" style=headlineStyle>${content.name}</a>
+                                                                                <a href=contentLink target="_blank" style=headlineStyle>${content.name}</a>
                                                                             </td>
                                                                         </tr>
                                                                         <tr>
@@ -108,7 +110,7 @@ $ const headlineStyle = {
                                                                         </tr>
                                                                         <tr>
                                                                             <td style="color: #555555; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 24px; padding: 0 0 12px 0;" align="left" class="body-text">
-                                                                                <a href=content.siteContext.url target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
+                                                                                <a href=contentLink target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
                                                                             </td>
                                                                         </tr>
                                                                     </table>
@@ -122,7 +124,6 @@ $ const headlineStyle = {
                                             <!-- /Two column -->
                                         </td>
                                     </tr>
-
                                 </table>
                             </td>
                         </tr>

--- a/packages/common/components/blocks/numeric/row-four.marko
+++ b/packages/common/components/blocks/numeric/row-four.marko
@@ -1,4 +1,5 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date, imagePath } = input;
 

--- a/packages/common/components/blocks/numeric/row-four.marko
+++ b/packages/common/components/blocks/numeric/row-four.marko
@@ -24,9 +24,11 @@ $ const queryParams = {
         <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
           <if(nodes.length)>
             $ const content = nodes[0];
+            $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+            $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
             <tr>
               <td style="padding: 16px 0; color: #000000; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 24px;" align="left">
-                <a href=content.siteContext.url target="_blank" style="text-decoration: none; color: #000000;">
+                <a href=contentLink target="_blank" style="text-decoration: none; color: #000000;">
                   ${content.name}
                 </a>
               </td>

--- a/packages/common/components/blocks/numeric/row-one-new.marko
+++ b/packages/common/components/blocks/numeric/row-one-new.marko
@@ -1,4 +1,5 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date, imagePath, colors } = input;
 

--- a/packages/common/components/blocks/numeric/row-one-new.marko
+++ b/packages/common/components/blocks/numeric/row-one-new.marko
@@ -58,6 +58,8 @@ $ const headlineStyle = {
                                         </td>
                                     </tr>
                                     $ const content = nodes[0];
+                                    $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                                    $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                                     <tr>
                                         <td dir="rtl" width="100%" style="padding: 24px 0 0 0;direction:rtl;" align="center" valign="top">
                                             <!-- Two column -->
@@ -79,7 +81,7 @@ $ const headlineStyle = {
                                                                                         class="img-max"
                                                                                         attrs={ style: imgStyles }
                                                                                         >
-                                                                                        <@link href=content.siteContext.url target="_blank" />
+                                                                                        <@link href=contentLink target="_blank" />
                                                                                         </marko-newsletter-imgix>
                                                                                     </marko-core-obj-value>
                                                                             </td>
@@ -98,7 +100,7 @@ $ const headlineStyle = {
                                                                     <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                                                         <tr>
                                                                             <td style="padding: 0 0 8px 0; color: #3c3c3c; font-family: Helvetica, Arial, sans-serif; font-size: 20px; font-weight: bold; line-height: 30px;" align="left" class="mobileheader">
-                                                                                <a href=content.siteContext.url target="_blank" style=headlineStyle>${content.name}</a>
+                                                                                <a href=contentLink target="_blank" style=headlineStyle>${content.name}</a>
                                                                             </td>
                                                                         </tr>
                                                                         <tr>
@@ -108,7 +110,7 @@ $ const headlineStyle = {
                                                                         </tr>
                                                                         <tr>
                                                                             <td style="color: #555555; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 24px; padding: 0 0 12px 0;" align="left" class="body-text">
-                                                                                <a href=content.siteContext.url target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
+                                                                                <a href=contentLink target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
                                                                             </td>
                                                                         </tr>
                                                                     </table>
@@ -122,7 +124,6 @@ $ const headlineStyle = {
                                             <!-- /Two column -->
                                         </td>
                                     </tr>
-
                                 </table>
                             </td>
                         </tr>

--- a/packages/common/components/blocks/numeric/row-one.marko
+++ b/packages/common/components/blocks/numeric/row-one.marko
@@ -1,4 +1,5 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date, imagePath } = input;
 

--- a/packages/common/components/blocks/numeric/row-one.marko
+++ b/packages/common/components/blocks/numeric/row-one.marko
@@ -25,9 +25,11 @@ $ const queryParams = {
         <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
           <if(nodes.length)>
             $ const content = nodes[0];
+            $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+            $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
             <tr>
               <td style="padding: 16px 0; color: #000000; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 24px;" align="left">
-                <a href=content.siteContext.url target="_blank" style="text-decoration: none; color: #000000;">
+                <a href=contentLink target="_blank" style="text-decoration: none; color: #000000;">
                   ${content.name}
                 </a>
               </td>

--- a/packages/common/components/blocks/numeric/row-three-new.marko
+++ b/packages/common/components/blocks/numeric/row-three-new.marko
@@ -36,7 +36,7 @@ $ const headlineStyle = {
      "text-decoration": "none"
 }
 
-<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=true params=queryParams>
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
     <if(nodes.length)>
         <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>

--- a/packages/common/components/blocks/numeric/row-three-new.marko
+++ b/packages/common/components/blocks/numeric/row-three-new.marko
@@ -1,4 +1,5 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date, imagePath, colors } = input;
 

--- a/packages/common/components/blocks/numeric/row-three-new.marko
+++ b/packages/common/components/blocks/numeric/row-three-new.marko
@@ -36,7 +36,7 @@ $ const headlineStyle = {
      "text-decoration": "none"
 }
 
-<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=true params=queryParams>
     <if(nodes.length)>
         <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
@@ -58,6 +58,8 @@ $ const headlineStyle = {
                                         </td>
                                     </tr>
                                     $ const content = nodes[0];
+                                    $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                                    $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                                     <tr>
                                         <td dir="rtl" width="100%" style="padding: 24px 0 0 0;direction:rtl;" align="center" valign="top">
                                             <!-- Two column -->
@@ -79,7 +81,7 @@ $ const headlineStyle = {
                                                                                         class="img-max"
                                                                                         attrs={ style: imgStyles }
                                                                                         >
-                                                                                        <@link href=content.siteContext.url target="_blank" />
+                                                                                        <@link href=contentLink target="_blank" />
                                                                                         </marko-newsletter-imgix>
                                                                                     </marko-core-obj-value>
                                                                             </td>
@@ -98,7 +100,7 @@ $ const headlineStyle = {
                                                                     <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                                                         <tr>
                                                                             <td style="padding: 0 0 8px 0; color: #3c3c3c; font-family: Helvetica, Arial, sans-serif; font-size: 20px; font-weight: bold; line-height: 30px;" align="left" class="mobileheader">
-                                                                                <a href=content.siteContext.url target="_blank" style=headlineStyle>${content.name}</a>
+                                                                                <a href=contentLink target="_blank" style=headlineStyle>${content.name}</a>
                                                                             </td>
                                                                         </tr>
                                                                         <tr>
@@ -108,7 +110,7 @@ $ const headlineStyle = {
                                                                         </tr>
                                                                         <tr>
                                                                             <td style="color: #555555; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 24px; padding: 0 0 12px 0;" align="left" class="body-text">
-                                                                                <a href=content.siteContext.url target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
+                                                                                <a href=contentLink target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
                                                                             </td>
                                                                         </tr>
                                                                     </table>
@@ -122,7 +124,6 @@ $ const headlineStyle = {
                                             <!-- /Two column -->
                                         </td>
                                     </tr>
-
                                 </table>
                             </td>
                         </tr>

--- a/packages/common/components/blocks/numeric/row-three.marko
+++ b/packages/common/components/blocks/numeric/row-three.marko
@@ -1,4 +1,5 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date, imagePath } = input;
 

--- a/packages/common/components/blocks/numeric/row-three.marko
+++ b/packages/common/components/blocks/numeric/row-three.marko
@@ -32,9 +32,11 @@ $ const queryParams = {
                     <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
                       <if(nodes.length)>
                         $ const content = nodes[0];
+                        $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                        $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                         <tr>
                           <td style="padding: 16px 0; color: #000000; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 24px;" align="left">
-                            <a href=content.siteContext.url target="_blank" style="text-decoration: none; color: #000000;">
+                            <a href=contentLink target="_blank" style="text-decoration: none; color: #000000;">
                               ${content.name}
                             </a>
                           </td>
@@ -63,9 +65,11 @@ $ const queryParams = {
                     <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=secondQueryParams>
                       <if(nodes.length)>
                         $ const content = nodes[0];
+                        $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                        $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                         <tr>
                           <td style="padding: 16px 0; color: #000000; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 24px;" align="left">
-                            <a href=content.siteContext.url target="_blank" style="text-decoration: none; color: #000000;">
+                            <a href=contentLink target="_blank" style="text-decoration: none; color: #000000;">
                             ${content.name}
                           </a>
                           </td>

--- a/packages/common/components/blocks/numeric/row-two-new.marko
+++ b/packages/common/components/blocks/numeric/row-two-new.marko
@@ -36,7 +36,7 @@ $ const headlineStyle = {
      "text-decoration": "none"
 }
 
-<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=true params=queryParams>
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
     <if(nodes.length)>
         <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>

--- a/packages/common/components/blocks/numeric/row-two-new.marko
+++ b/packages/common/components/blocks/numeric/row-two-new.marko
@@ -1,4 +1,5 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date, imagePath, colors } = input;
 

--- a/packages/common/components/blocks/numeric/row-two-new.marko
+++ b/packages/common/components/blocks/numeric/row-two-new.marko
@@ -36,7 +36,7 @@ $ const headlineStyle = {
      "text-decoration": "none"
 }
 
-<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=true params=queryParams>
     <if(nodes.length)>
         <table border="0" cellpadding="0" cellspacing="0" width="100%">
             <tr>
@@ -58,6 +58,8 @@ $ const headlineStyle = {
                                         </td>
                                     </tr>
                                     $ const content = nodes[0];
+                                    $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                                    $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                                     <tr>
                                         <td dir="rtl" width="100%" style="padding: 24px 0 0 0;direction:rtl;" align="center" valign="top">
                                             <!-- Two column -->
@@ -79,7 +81,7 @@ $ const headlineStyle = {
                                                                                         class="img-max"
                                                                                         attrs={ style: imgStyles }
                                                                                         >
-                                                                                        <@link href=content.siteContext.url target="_blank" />
+                                                                                        <@link href=contentLink target="_blank" />
                                                                                         </marko-newsletter-imgix>
                                                                                     </marko-core-obj-value>
                                                                             </td>
@@ -98,7 +100,7 @@ $ const headlineStyle = {
                                                                     <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                                                         <tr>
                                                                             <td style="padding: 0 0 8px 0; color: #3c3c3c; font-family: Helvetica, Arial, sans-serif; font-size: 20px; font-weight: bold; line-height: 30px;" align="left" class="mobileheader">
-                                                                                <a href=content.siteContext.url target="_blank" style=headlineStyle>${content.name}</a>
+                                                                                <a href=contentLink target="_blank" style=headlineStyle>${content.name}</a>
                                                                             </td>
                                                                         </tr>
                                                                         <tr>
@@ -108,7 +110,7 @@ $ const headlineStyle = {
                                                                         </tr>
                                                                         <tr>
                                                                             <td style="color: #555555; font-family: Helvetica, Arial, sans-serif; font-size: 16px; font-weight: normal; line-height: 24px; padding: 0 0 12px 0;" align="left" class="body-text">
-                                                                                <a href=content.siteContext.url target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
+                                                                                <a href=contentLink target="_blank" style="color: #27BCE2; text-decoration: underline;">Read More →</a>
                                                                             </td>
                                                                         </tr>
                                                                     </table>
@@ -122,7 +124,6 @@ $ const headlineStyle = {
                                             <!-- /Two column -->
                                         </td>
                                     </tr>
-
                                 </table>
                             </td>
                         </tr>

--- a/packages/common/components/blocks/numeric/row-two.marko
+++ b/packages/common/components/blocks/numeric/row-two.marko
@@ -47,9 +47,11 @@ $ const queryParams = {
                     <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
                       <if(nodes.length)>
                         $ const content = nodes[0];
+                        $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                        $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                         <tr>
                           <td style="padding: 16px 0; color: #000000; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 24px;" align="left">
-                            <a href=content.siteContext.url target="_blank" style="text-decoration: none; color: #000000;">
+                            <a href=contentLink target="_blank" style="text-decoration: none; color: #000000;">
                               ${content.name}
                             </a>
                           </td>

--- a/packages/common/components/blocks/numeric/row-two.marko
+++ b/packages/common/components/blocks/numeric/row-two.marko
@@ -1,4 +1,5 @@
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date, imagePath } = input;
 

--- a/packages/common/components/blocks/standard/content-list-item.marko
+++ b/packages/common/components/blocks/standard/content-list-item.marko
@@ -7,7 +7,10 @@ $ const withImage = defaultValue(input.withImage, true);
 $ const button = defaultValue(input.button, false);
 
 $ const companyPromo = (content.type === 'promotion' && content.company);
-$ const slug = companyPromo ? `Presented by ${content.company.name}` : content.primarySection.name;
+$ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+$ const contentPrimarySectionName = primarySiteIsProSource ? get(content, "prosourcePrimarySection.name") : get(content, "primarySection.name")
+$ const slug = companyPromo ? `Presented by ${content.company.name}` : contentPrimarySectionName;
+$ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
 
 $ const imgStyles = {
   "display": "block",
@@ -41,7 +44,7 @@ $ const imgStyles = {
                           class="img-max"
                           attrs={ style: imgStyles }
                         >
-                          <@link href=content.siteContext.url target="_blank" />
+                          <@link href=contentLink target="_blank" />
                         </marko-newsletter-imgix>
                       </marko-core-obj-value>
                     </td>
@@ -65,7 +68,7 @@ $ const imgStyles = {
                   </tr>
                   <tr>
                     <td style="padding: 0 0 12px 0; color: #3c3c3c; font-family: Helvetica, Arial, sans-serif; font-size: 20px; font-weight: bold; line-height: 26px;">
-                      <a href=content.siteContext.url style="color: #3c3c3c; text-decoration: none;" target="_blank">
+                      <a href=contentLink style="color: #3c3c3c; text-decoration: none;" target="_blank">
                         ${content.name}
                       </a>
                     </td>

--- a/packages/common/components/blocks/standard/feature-content.marko
+++ b/packages/common/components/blocks/standard/feature-content.marko
@@ -39,6 +39,8 @@ $ const queryParams = {
       <!-- <common-list-header-element title=sectionName /> -->
     </if>
     <for|content| of=nodes>
+      $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+      $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
       <!-- Main Feature -->
       <table border="0" cellpadding="0" cellspacing="0" width="100%">
         <tr>
@@ -65,7 +67,7 @@ $ const queryParams = {
                                         class="img-max"
                                         attrs={ style: imgStyles, border: 0 }
                                       >
-                                        <@link href=content.siteContext.url target="_blank" />
+                                        <@link href=contentLink target="_blank" />
                                       </marko-newsletter-imgix>
                                     </marko-core-obj-value>
                                   </td>
@@ -84,7 +86,7 @@ $ const queryParams = {
                               <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                 <tr>
                                   <td style="padding: 0 0 8px 0; color: #3c3c3c; font-family: Helvetica, Arial, sans-serif; font-size: 22px; font-weight: bold; line-height: 30px;" align="left" class="mobileheader">
-                                      <a href=content.siteContext.url target="_blank" style="color: #3c3c3c; text-decoration: none;">
+                                      <a href=contentLink target="_blank" style="color: #3c3c3c; text-decoration: none;">
                                       ${content.name}
                                       </a>
                                   </td>

--- a/packages/common/components/blocks/standard/product-list.marko
+++ b/packages/common/components/blocks/standard/product-list.marko
@@ -65,6 +65,8 @@ $ const queryParams = {
                       <!-- content -->
                       <table border="0" cellpadding="0" cellspacing="0" width="100%">
                         <for|content| of=nodes>
+                          $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                          $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                           <!-- begin -->
                           <tr>
                             <td style="padding: 20px 0 0 0;" align="center" valign="top" class="mobile-padding-topbtm">
@@ -96,7 +98,7 @@ $ const queryParams = {
                                               class="img-max"
                                               attrs={ style: imgStyles, border: 0, width: 176, height: 132 }
                                             >
-                                              <@link href=content.siteContext.url target="_blank" />
+                                              <@link href=contentLink target="_blank" />
                                             </marko-newsletter-imgix>
                                           </marko-core-obj-value>
                                         </td>
@@ -112,7 +114,7 @@ $ const queryParams = {
                                           <table border="0" cellpadding="0" cellspacing="0" width="100%">
                                             <tr>
                                               <td style="padding: 0 0 8px 0; color: #3c3c3c; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight:bold; line-height: 26px;">
-                                                <a href=content.siteContext.url target="_blank" style="color: #3c3c3c; text-decoration: none;">
+                                                <a href=contentLink target="_blank" style="color: #3c3c3c; text-decoration: none;">
                                                   ${content.name}
                                                 </a>
                                               </td>

--- a/packages/common/components/blocks/standard/product-list.marko
+++ b/packages/common/components/blocks/standard/product-list.marko
@@ -1,5 +1,6 @@
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+import { get } from "@parameter1/base-cms-object-path";
 
 $ const { newsletter, date } = input;
 

--- a/packages/common/components/blocks/standard/sponsor.marko
+++ b/packages/common/components/blocks/standard/sponsor.marko
@@ -38,6 +38,8 @@ $ const imgStyles = {
                       <!-- content right -->
                       <td align="right" class="companylogo-imgflex" style="vertical-align:middle;height:65px;" valign="middle" width="48%">
                         <table border="0" cellpadding="0" cellspacing="0" width="100%">
+                          $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+                          $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
                           <tr>
                             <td align="left" style="height:65px;">
                               <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
@@ -48,7 +50,7 @@ $ const imgStyles = {
                                   class="img-max"
                                   attrs={ style: imgStyles, border: 0 }
                                 >
-                                  <@link href=content.siteContext.url target="_blank" />
+                                  <@link href=contentLinktarget="_blank" />
                                 </marko-newsletter-imgix>
                               </marko-core-obj-value>
                             </td>

--- a/packages/common/components/blocks/standard/trending-list.marko
+++ b/packages/common/components/blocks/standard/trending-list.marko
@@ -40,6 +40,8 @@ $ const queryParams = {
               </td>
             </tr>
             <for|content| of=nodes>
+              $ const primarySiteIsProSource = get(content, "primarySite.shortName") === "PS";
+              $ const contentLink = primarySiteIsProSource ? `https://www.prosource.org/${content.id}`: content.siteContext.url;
               <tr>
                 <td align="center" valign="top" width="100%" style="padding-bottom:24px;">
                   <!-- Two column -->
@@ -65,7 +67,7 @@ $ const queryParams = {
                                   options={ w: 112 }
                                   attrs={ style: imgStyles }
                                 >
-                                  <@link href=content.siteContext.url target="_blank" />
+                                  <@link href=contentLink target="_blank" />
                                 </marko-newsletter-imgix>
                               </marko-core-obj-value>
                             </td>
@@ -97,7 +99,7 @@ $ const queryParams = {
                                 <!-- ........ -->
                                 <tr>
                                   <td style="padding: 0 0 8px 0; color: #3c3c3c; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 28px;" align="left">
-                                    <a href=content.siteContext.url target="_blank" style="color: #3c3c3c; text-decoration: none;">
+                                    <a href=contentLink target="_blank" style="color: #3c3c3c; text-decoration: none;">
                                       ${content.name}
                                     </a>
                                   </td>

--- a/packages/common/graphql/fragments/content-list.js
+++ b/packages/common/graphql/fragments/content-list.js
@@ -32,6 +32,9 @@ fragment NewsletterContentListFragment on Content {
   primarySection {
     name
   }
+  prosourcePrimarySection: primarySection(input: { siteId: "624490387ae702f0058b45b8" }) {
+    name
+  }
   ... on ContentPromotion {
     name(input: { mutation: Email })
     teaser(input: { mutation: Email, useFallback: false, maxLength: null })


### PR DESCRIPTION
![Screenshot from 2024-02-07 13-40-18](https://github.com/parameter1/pmmi-media-group-newsletters/assets/46794001/7e263b1b-da1f-4194-b21f-c1063540cb55)
