### PR TITLE
Remove title from newsletter-root in weekly, new-alert, & mundo layouts

### DIFF
--- a/packages/common/components/layouts/2024-mundo.marko
+++ b/packages/common/components/layouts/2024-mundo.marko
@@ -7,10 +7,7 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const title = get(newsletterConfig, "title");
 $ const emailX = config.get('emailX');
 
-<marko-newsletter-root
-  title=title
-  date=date
->
+<marko-newsletter-root date=date>
   <@head>
     <common-2024-head-block title=title newsletter=newsletter />
   </@head>

--- a/packages/common/components/layouts/2024-new-issue.marko
+++ b/packages/common/components/layouts/2024-new-issue.marko
@@ -7,10 +7,7 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const title = get(newsletterConfig, "title");
 $ const emailX = config.get('emailX');
 
-<marko-newsletter-root
-  title=title
-  date=date
->
+<marko-newsletter-root date=date>
   <@head>
     <common-2024-head-block title=title newsletter=newsletter />
   </@head>

--- a/packages/common/components/layouts/2024-weekly.marko
+++ b/packages/common/components/layouts/2024-weekly.marko
@@ -7,10 +7,7 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const title = get(newsletterConfig, "title");
 $ const emailX = config.get('emailX');
 
-<marko-newsletter-root
-  title=title
-  date=date
->
+<marko-newsletter-root date=date>
   <@head>
     <common-2024-head-block title=title newsletter=newsletter />
   </@head>


### PR DESCRIPTION
DEV:
<img width="1791" alt="Screenshot 2024-03-18 at 8 13 56 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/43587c64-83d4-406d-bf9b-a1cf5f7fcab6">
<img width="1792" alt="Screenshot 2024-03-18 at 8 14 18 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/8a308868-7700-4f7e-9f15-976d7b7a779f">
<img width="1792" alt="Screenshot 2024-03-18 at 8 16 05 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/10c2f12f-10f6-43fe-975a-90a74c35c63e">

PROD:
<img width="1792" alt="Screenshot 2024-03-18 at 8 14 43 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/a7ca4630-4960-4fc1-be2f-f2558e9b26c2">
<img width="1792" alt="Screenshot 2024-03-18 at 8 15 16 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/f1213d1e-01cb-4c55-b8d0-afdb3f76f305">
<img width="1789" alt="Screenshot 2024-03-18 at 8 15 50 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/bb96d351-e005-4f86-a786-90d59f0468a1">
