### PR TITLE
Add tenant matrix to build-newsletters workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -50,6 +50,11 @@ jobs:
   build-newsletters:
     needs: [version]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tenant:
+          - all
+          - mundo
     steps:
       - uses: actions/checkout@v3
       - name: Log in to ECR


### PR DESCRIPTION
Missed in: https://github.com/parameter1/pmmi-media-group-newsletters/pull/173