### PR TITLE
Correct Email-X API URI for Mundo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ x-env-defaults: &env
   NODE_ENV: development
   NEW_RELIC_ENABLED: ${NEW_RELIC_ENABLED-0}
   NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY-(unset)}
-  EMAILX_SERVE_URI: ${EMAILX_SERVE_URI-https://pmmi.serve.email-x.parameter1.com}
 
 x-env-leonis: &env-leonis
   <<: *env

--- a/tenants/mundo/config/email-x.js
+++ b/tenants/mundo/config/email-x.js
@@ -1,6 +1,6 @@
 const EmailXConfiguration = require('@parameter1/base-cms-marko-newsletters-email-x/config');
 
-const config = new EmailXConfiguration(process.env.EMAILX_SERVE_URI || 'https://pmmi.serve.email-x.parameter1.com');
+const config = new EmailXConfiguration('https://delivery.mindfulcms.com/pmmi/default/compat/email-banner');
 
 config
   .setAdUnits('mundo-perspectivas', [


### PR DESCRIPTION
![image](https://github.com/parameter1/pmmi-media-group-newsletters/assets/46794001/fa647149-af64-45c6-a854-87142bf8dbbf)

This was additionally missed in https://github.com/parameter1/pmmi-media-group-newsletters/pull/177 and subsequently via https://github.com/parameter1/pmmi-media-group-newsletters/pull/179