### PR TITLE
Copy over image styling from ‘old’ numeric template

### DIFF
--- a/packages/common/components/blocks/numeric/row.marko
+++ b/packages/common/components/blocks/numeric/row.marko
@@ -16,6 +16,13 @@ $ const queryParams = {
   queryFragment,
 };
 
+$ const imgStyles = {
+  "display": "block",
+  "max-width": "240px",
+  "max-height": "240px",
+  "border-width": "0px",
+};
+
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
   <if(nodes.length)>
     $ const content = nodes[0];
@@ -37,8 +44,8 @@ $ const queryParams = {
                       <marko-newsletter-imgix
                         src=image.src
                         alt=image.alt
-                        options={ w: 240 }
-                        attrs={ width: 240 }
+                        options={ w: 240, h: 240, fit: "crop" }
+                        attrs={ style: imgStyles }
                         class="adapt-img"
                       >
                         <@link href=contentLink target="_blank" />


### PR DESCRIPTION
<img width="747" alt="Screenshot 2024-06-10 at 11 28 10 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/5028f0f3-37eb-405c-a361-02059a00c4bf">
