### PR TITLE
Change name of CMP editor’s image

### DIFF
--- a/tenants/all/config/core.js
+++ b/tenants/all/config/core.js
@@ -164,7 +164,7 @@ const config = {
       src: '/files/base/pmmi/all/image/newsletters/cmpnlheader.png',
     },
     editor: {
-      src: '/files/base/pmmi/all/image/newsletters/cmp-editor.png',
+      src: '/files/base/pmmi/all/image/newsletters/cmp-editor-joseph.png',
       width: '50',
       name: 'Joseph Derr',
       title: 'Editor',


### PR DESCRIPTION
<img width="676" alt="Screenshot 2024-06-18 at 7 35 45 AM" src="https://github.com/parameter1/pmmi-media-group-newsletters/assets/64623209/e0a7b07e-248d-408b-bbd5-eeb660976270">
