### PR TITLE
Set image options to double the attrs size

### DIFF
--- a/packages/common/components/blocks/2024/header.marko
+++ b/packages/common/components/blocks/2024/header.marko
@@ -27,8 +27,9 @@ $ const primaryColor = get(newsletterConfig, "primaryColor");
                       <td align="center" style="padding:0;margin:0;font-size:0px">
                         <marko-newsletter-imgix
                           src=header.src
-                          options={ w: 640, auto: "format,compress", q: 100 }
+                          options={ w: 1280, auto: "format,compress", q: 100 }
                           class="adapt-img"
+                          attrs={ width: 640 }
                         />
                       </td>
                     </tr>

--- a/packages/common/components/blocks/numeric/header.marko
+++ b/packages/common/components/blocks/numeric/header.marko
@@ -34,9 +34,10 @@ $ const logoSrc = get(newsletterConfig, "logoSrc");
                         <td align="center" style="padding:0;margin:0;font-size:0px">
                           <marko-newsletter-imgix
                             src=logoSrc
-                            options={ w: 600, auto: "format,compress", q: 100 }
+                            options={ w: 1200, auto: "format,compress", q: 100 }
                             alt=brandName
                             class="adapt-img"
+                            attrs={ width: 600 }
                           />
                         </td>
                       </tr>
@@ -98,9 +99,10 @@ $ const logoSrc = get(newsletterConfig, "logoSrc");
                         <td align="center" style="padding:20px;margin:0;font-size:0px">
                           <marko-newsletter-imgix
                             src=logoSrc
-                            options={ w: 600, auto: "format,compress", q: 100 }
+                            options={ w: 1200, auto: "format,compress", q: 100 }
                             alt=brandName
                             class="adapt-img"
+                            attrs={ width: 600 }
                           />
                         </td>
                       </tr>


### PR DESCRIPTION
<img width="1790" alt="Screenshot 2024-08-27 at 9 04 19 AM" src="https://github.com/user-attachments/assets/942f69a9-7efb-4b72-a2da-84edeb1f505b">
<img width="1792" alt="Screenshot 2024-08-27 at 9 08 57 AM" src="https://github.com/user-attachments/assets/15826132-fabb-4417-88a4-00fa8c59d0b2">
