### PR TITLE
Update 'Up Next' section in Pack Expo

### DIFF
--- a/packages/common/components/blocks/expo/schedule-list-item.marko
+++ b/packages/common/components/blocks/expo/schedule-list-item.marko
@@ -22,7 +22,7 @@ $ const { newsletter, date, content, sectionName } = input;
                   </tr>
                   <tr>
                     <td style="padding: 0 0 12px 0; color: #3a3636; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 24px;">
-                      <a href="https://packexpo23.mapyourshow.com/8_0/sessions/session-details.cfm?scheduleid=237" target="_blank" style="color: #3a3636; text-decoration: none;">
+                      <a href=content.siteContext.url target="_blank" style="color: #3a3636; text-decoration: none;">
                         ${content.name}
                       </a>
                     </td>

--- a/packages/common/components/layouts/expo.marko
+++ b/packages/common/components/layouts/expo.marko
@@ -11,7 +11,7 @@ $ const newsletterName = get(newsletterConfig, "name");
 $ const newsletterDescription = stripHtml(get(newsletterConfig, "description"));
 $ const title = get(newsletterConfig, "title");
 
-$ const displayDate = moment(date).add(1, "days").format("dddd, MMMM DD");
+$ const displayDate = moment(date).add(1, "days").format("dddd, MMMM D");
 
 <marko-newsletter-root
   title=title


### PR DESCRIPTION
<img width="876" alt="Screenshot 2024-10-30 at 7 53 44 AM" src="https://github.com/user-attachments/assets/a29f24e1-8170-4f0a-8375-d9dc0dccc0db">
<img width="498" alt="Screenshot 2024-10-30 at 10 26 54 AM" src="https://github.com/user-attachments/assets/c3af59a9-06e7-4f80-9c25-14860d4f9bd5">
