### PR TITLE
Ensure  correct 'view online' font-size on mobile

### DIFF
--- a/packages/common/components/blocks/2024-head.marko
+++ b/packages/common/components/blocks/2024-head.marko
@@ -77,6 +77,12 @@ $ const title = get(newsletterConfig, "title");
     .es-infoblock p, .es-infoblock ul li, .es-infoblock ol li, .es-infoblock a {
       font-size:18px!important
     }
+    .view-online { 
+      padding-right:0!important
+    }
+    .view-online a {
+      font-size:14px!important;
+    }
     *[class="gmail-fix"] { display:none!important }
     .es-m-txt-c, .es-m-txt-c h1, .es-m-txt-c h2, .es-m-txt-c h3 { text-align:center!important }
     .es-m-txt-r, .es-m-txt-r h1, .es-m-txt-r h2, .es-m-txt-r h3 { text-align:right!important }

--- a/packages/common/components/blocks/2024/date-banner.marko
+++ b/packages/common/components/blocks/2024/date-banner.marko
@@ -88,7 +88,7 @@ $ const displayDate = (lang) ? moment(date).locale(lang).format("D, YYYY") : mom
                       </td>
                     </tr>
                     <tr>
-                      <td align="right" class="es-m-p0r" style="padding:0;Margin:0;padding-right:20px">
+                      <td align="right" class="view-online" style="Margin:0;padding-right:20px">
                         <h4 style="Margin:0;line-height:21px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;font-size:12px;color:#333333">
                           <strong><a target="_blank" href="https://placeholder.com" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:underline;color:#333333;font-size:14px">View Digital Edition</a></strong>
                         </h4>


### PR DESCRIPTION
Desktop:
<img width="813" alt="Screenshot 2024-11-13 at 2 01 23 PM" src="https://github.com/user-attachments/assets/e415f3bc-af18-415e-af9b-f3e38d3f0019">
Mobile:
<img width="806" alt="Screenshot 2024-11-13 at 2 08 52 PM" src="https://github.com/user-attachments/assets/5eed29b8-ab9b-4328-9080-91670c7f350d">
