### PR TITLE
Adjust promo block to match 2024 layout

### DIFF
--- a/packages/common/components/blocks/sustainable/promo.marko
+++ b/packages/common/components/blocks/sustainable/promo.marko
@@ -47,7 +47,7 @@ $ const linkAttrs = {
     <td align="left" style="margin:0;padding-right:40px;padding-bottom:10px;padding-left:40px;padding-top:10px"><!--[if mso]><table style="width:560px" cellpadding="0" cellspacing="0"><tr><td style="width:96px" valign="top"><![endif]-->
       <table align="left" cellspacing="0" cellpadding="0" class="es-left" role="none" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px;float:left">
         <tr>
-          <td align="left" style="padding:0;margin:0;width:96px">
+          <td class="es-m-p20b" align="left" style="padding:0;margin:0;width:96px">
             <table width="100%" cellspacing="0" cellpadding="0" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
               <tr>
                 <td align="center" style="padding:0;margin:0;font-size:0px">
@@ -71,17 +71,19 @@ $ const linkAttrs = {
           <td align="left" style="padding:0;margin:0;width:444px">
             <table width="100%" cellspacing="0" cellpadding="0" role="presentation" style="mso-table-lspace:0pt;mso-table-rspace:0pt;border-collapse:collapse;border-spacing:0px">
               <tr>
-                <td align="left" class="es-m-p0t" style="padding:0;margin:0;">
-                  <h2 class="es-m-txt-c" style="margin:0;font-family:arial, 'helvetica neue', helvetica, sans-serif;mso-line-height-rule:exactly;letter-spacing:0;font-size:18px;font-style:normal;font-weight:bold;line-height:27px;color:#333333">
+                <td align="left" class="es-m-txt-c es-m-p0t" style="padding:0;margin:0;padding-top:10px;padding-bottom:10px">
+                  <h2 style="margin:0;font-family:arial, 'helvetica neue', helvetica, sans-serif;mso-line-height-rule:exactly;letter-spacing:0;font-size:18px;font-style:normal;font-weight:bold;line-height:27px;color:#333333">
                     <strong>${content.name}</strong>
                   </h2>
                 </td>
               </tr>
               <tr>
-                <td align="left" class="es-m-txt-c" style="margin:0;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:27px;letter-spacing:0;color:#333333;font-size:14px">
-                  <a href=url target="_blank" style="mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:18px" ...linkAttrs>
-                    <u>$!{content.teaser}</u>
-                  </a>
+                <td align="left" class="es-m-txt-c" style="padding:0;margin:0">
+                  <div class="teaser" style="margin:0;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:27px;letter-spacing:0;color:#333333;font-size:14px">
+                    <a href=url target="_blank" style="mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:18px" ...linkAttrs>
+                      <u>$!{content.teaser}</u>
+                    </a>
+                  </div>
                 </td>
               </tr>
             </table>
@@ -117,9 +119,9 @@ $ const linkAttrs = {
               </tr>
               <tr>
                 <td align="left" style="padding:0;margin:0">
-                  <p style="margin:0;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;letter-spacing:0;color:#333333;font-size:14px">
+                  <div style="margin:0;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;letter-spacing:0;color:#333333;font-size:14px" class="teaser">
                     $!{content.teaser}
-                  </p>
+                  </div>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
To match with what Hannah is comparing in her screenshot:
<img width="580" alt="Screenshot 2025-04-08 at 7 42 10 AM" src="https://github.com/user-attachments/assets/99f5f047-6388-481d-96f9-aa62480387a5" />
