### PR TITLE
Adjust the webinars block to back fill only when there are not 3 upcoming webinars

### DIFF
--- a/packages/common/components/blocks/2024/webinar-mundo.marko
+++ b/packages/common/components/blocks/2024/webinar-mundo.marko
@@ -9,12 +9,14 @@ $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
 $ const newsletterConfig = config.get(newsletter.alias);
 $ const brandShort = get(newsletterConfig, "brandShort");
 $ const primaryColor = get(newsletterConfig, "primaryColor");
+$ const displayLimit = 3;
+$ const upcomingLimit = displayLimit;
 
 $ const upcomingQueryParams = {
   includeContentTypes: ["Webinar"],
   queryFragment,
   beginningAfter: mailDate,
-  limit: 2,
+  limit: upcomingLimit,
   sort: {
     field: "startDate",
     order: "asc",
@@ -28,8 +30,8 @@ $ const archiveQueryParams = {
     field: "startDate",
     order: "desc",
   },
-  limit: 1,
 };
+
 $ const sectionNameStyle = {
   "margin": "0",
   "mso-line-height-rule": "exactly",
@@ -55,9 +57,9 @@ $ const sectionNameStyle = {
                 </h3>
               </td>
             </tr>
-            <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=upcomingQueryParams>
-              <if(nodes.length)>
-                <for|content| of=nodes>
+            <marko-web-query|{ nodes: upcomingNodes }| name="website-scheduled-content" collapsible=false params=upcomingQueryParams>
+              <if(upcomingNodes.length)>
+                <for|content| of=upcomingNodes>
                   $ const contentLinkUrl = new URL(content.linkUrl);
                   $ const { searchParams } = contentLinkUrl
                   $ searchParams.set('ref', `${brandShort}-news`);
@@ -82,32 +84,35 @@ $ const sectionNameStyle = {
                   </tr>
                 </for>
               </if>
-            </marko-web-query>
-            <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=archiveQueryParams>
-              <if(nodes.length)>
-                <for|content| of=nodes>
-                  $ const contentLinkUrl = new URL(content.linkUrl);
-                  $ const { searchParams } = contentLinkUrl
-                  $ searchParams.set('ref', `${brandShort}-news`);
-                  <tr>
-                    <td align="left" style="padding:0;margin:0;padding-bottom:5px">
-                      <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
-                        Disponible ahora bajo demanda
-                      </p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td align="left" style="padding:0;margin:0;padding-bottom:20px">
-                      <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                        <strong>
-                          <a href=`${contentLinkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
-                            ${content.name}
-                          </a>
-                        </strong>
-                      </p>
-                    </td>
-                  </tr>
-                </for>
+              $ archiveQueryParams.limit = displayLimit - upcomingNodes.length;
+              <if(archiveQueryParams.limit)>
+                <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=archiveQueryParams>
+                  <if(nodes.length)>
+                    <for|content| of=nodes>
+                      $ const contentLinkUrl = new URL(content.linkUrl);
+                      $ const { searchParams } = contentLinkUrl
+                      $ searchParams.set('ref', `${brandShort}-news`);
+                      <tr>
+                        <td align="left" style="padding:0;margin:0;padding-bottom:5px">
+                          <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
+                            Disponible ahora bajo demanda
+                          </p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td align="left" style="padding:0;margin:0;padding-bottom:20px">
+                          <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                            <strong>
+                              <a href=`${contentLinkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                                ${content.name}
+                              </a>
+                            </strong>
+                          </p>
+                        </td>
+                      </tr>
+                    </for>
+                  </if>
+                </marko-web-query>
               </if>
             </marko-web-query>
           </table>

--- a/packages/common/components/blocks/2024/webinar.marko
+++ b/packages/common/components/blocks/2024/webinar.marko
@@ -10,12 +10,14 @@ $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
 $ const newsletterConfig = config.get(newsletter.alias);
 $ const brandShort = get(newsletterConfig, "brandShort");
 $ const primaryColor = get(newsletterConfig, "primaryColor");
+$ const displayLimit = 3;
+$ const featureDisplayLimit = 2;
 
 $ const upcomingQueryParams = {
   includeContentTypes: ["Webinar"],
   queryFragment,
   beginningAfter: mailDate,
-  limit: 2,
+  limit: featureDisplayLimit,
   sort: {
     field: "startDate",
     order: "asc",
@@ -29,7 +31,6 @@ $ const archiveQueryParams = {
     field: "startDate",
     order: "desc",
   },
-  limit: 1,
 };
 
 $ const sectionNameStyle = {
@@ -56,9 +57,9 @@ $ const sectionNameStyle = {
                 </h3>
               </td>
             </tr>
-            <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=upcomingQueryParams>
-              <if(nodes.length)>
-                <for|content| of=nodes>
+            <marko-web-query|{ nodes: upcomingNodes }| name="website-scheduled-content" collapsible=false params=upcomingQueryParams>
+              <if(upcomingNodes.length)>
+                <for|content| of=upcomingNodes>
                   $ const contentLinkUrl = new URL(content.linkUrl);
                   $ const { searchParams } = contentLinkUrl
                   $ searchParams.set('ref', `${brandShort}-news`);
@@ -83,33 +84,34 @@ $ const sectionNameStyle = {
                   </tr>
                 </for>
               </if>
-            </marko-web-query>
-            <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=archiveQueryParams>
-              <if(nodes.length)>
-                <for|content| of=nodes>
-                  $ const contentLinkUrl = new URL(content.linkUrl);
-                  $ const { searchParams } = contentLinkUrl
-                  $ searchParams.set('ref', `${brandShort}-news`);
-                  <tr>
-                    <td align="left" style="padding:0;margin:0;padding-bottom:5px">
-                      <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
-                        Now Available On-Demand
-                      </p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td align="left" style="padding:0;margin:0;padding-bottom:10px">
-                      <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                        <strong>
-                          <a href=`${contentLinkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
-                            ${content.name}
-                          </a>
-                        </strong>
-                      </p>
-                    </td>
-                  </tr>
-                </for>
-              </if>
+              $ archiveQueryParams.limit = displayLimit - upcomingNodes.length;
+              <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=archiveQueryParams>
+                <if(nodes.length)>
+                  <for|content| of=nodes>
+                    $ const contentLinkUrl = new URL(content.linkUrl);
+                    $ const { searchParams } = contentLinkUrl
+                    $ searchParams.set('ref', `${brandShort}-news`);
+                    <tr>
+                      <td align="left" style="padding:0;margin:0;padding-bottom:5px">
+                        <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
+                          Now Available On-Demand
+                        </p>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="left" style="padding:0;margin:0;padding-bottom:10px">
+                        <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                          <strong>
+                            <a href=`${contentLinkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                              ${content.name}
+                            </a>
+                          </strong>
+                        </p>
+                      </td>
+                    </tr>
+                  </for>
+                </if>
+              </marko-web-query>
             </marko-web-query>
           </table>
         </td>

--- a/packages/common/components/blocks/2024/webinar.marko
+++ b/packages/common/components/blocks/2024/webinar.marko
@@ -11,13 +11,13 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const brandShort = get(newsletterConfig, "brandShort");
 $ const primaryColor = get(newsletterConfig, "primaryColor");
 $ const displayLimit = 3;
-$ const featureDisplayLimit = 2;
+$ const upcomingLimit = displayLimit;
 
 $ const upcomingQueryParams = {
   includeContentTypes: ["Webinar"],
   queryFragment,
   beginningAfter: mailDate,
-  limit: featureDisplayLimit,
+  limit: upcomingLimit,
   sort: {
     field: "startDate",
     order: "asc",

--- a/packages/common/components/blocks/2024/webinar.marko
+++ b/packages/common/components/blocks/2024/webinar.marko
@@ -85,33 +85,35 @@ $ const sectionNameStyle = {
                 </for>
               </if>
               $ archiveQueryParams.limit = displayLimit - upcomingNodes.length;
-              <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=archiveQueryParams>
-                <if(nodes.length)>
-                  <for|content| of=nodes>
-                    $ const contentLinkUrl = new URL(content.linkUrl);
-                    $ const { searchParams } = contentLinkUrl
-                    $ searchParams.set('ref', `${brandShort}-news`);
-                    <tr>
-                      <td align="left" style="padding:0;margin:0;padding-bottom:5px">
-                        <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
-                          Now Available On-Demand
-                        </p>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td align="left" style="padding:0;margin:0;padding-bottom:10px">
-                        <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
-                          <strong>
-                            <a href=`${contentLinkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
-                              ${content.name}
-                            </a>
-                          </strong>
-                        </p>
-                      </td>
-                    </tr>
-                  </for>
-                </if>
-              </marko-web-query>
+              <if(archiveQueryParams.limit)>
+                <marko-web-query|{ nodes }| name="website-scheduled-content" collapsible=false params=archiveQueryParams>
+                  <if(nodes.length)>
+                    <for|content| of=nodes>
+                      $ const contentLinkUrl = new URL(content.linkUrl);
+                      $ const { searchParams } = contentLinkUrl
+                      $ searchParams.set('ref', `${brandShort}-news`);
+                      <tr>
+                        <td align="left" style="padding:0;margin:0;padding-bottom:5px">
+                          <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#999999;font-size:14px">
+                            Now Available On-Demand
+                          </p>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td align="left" style="padding:0;margin:0;padding-bottom:10px">
+                          <p style="margin:0;-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;color:#333333;font-size:14px">
+                            <strong>
+                              <a href=`${contentLinkUrl}` target="_blank" style="-webkit-text-size-adjust:none;-ms-text-size-adjust:none;mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                                ${content.name}
+                              </a>
+                            </strong>
+                          </p>
+                        </td>
+                      </tr>
+                    </for>
+                  </if>
+                </marko-web-query>
+              </if>
             </marko-web-query>
           </table>
         </td>

--- a/packages/common/components/blocks/sustainable/webinar.marko
+++ b/packages/common/components/blocks/sustainable/webinar.marko
@@ -88,14 +88,17 @@ $ const sectionNameStyle = {
                 </tr>
               </for>
               $ const archiveLimit = displayLimit - upcoming.length
+              
               <if(archiveLimit !== 0)>
                 $ const archivePromise = webinarLoader(apollo, { 
                   siteIds,
-                  params: archiveQueryParams,
-                  limit: archiveLimit,
+                  params: {
+                    ...archiveQueryParams,
+                    limit: archiveLimit,
+                  }
                 });
                 <marko-web-resolve|{ resolved }| promise=archivePromise>
-                  $ const { archives } = resolved
+                  $ const { schedules: archives } = resolved
                   <for|content| of=archives>
                     $ const contentLinkUrl = new URL(content.linkUrl);
                     $ const { searchParams } = contentLinkUrl

--- a/packages/common/components/blocks/sustainable/webinar.marko
+++ b/packages/common/components/blocks/sustainable/webinar.marko
@@ -11,13 +11,15 @@ $ const dateFormat = defaultValue(input.dateFormat, "MMMM DD, YYYY");
 $ const newsletterConfig = config.get(newsletter.alias);
 $ const brandShort = get(newsletterConfig, "brandShort");
 $ const primaryColor = get(newsletterConfig, "primaryColor");
+$ const displayLimit = 3;
+$ const upcomingLimit = 3;
 
 $ const siteIds = ['5d88cef7f175132c008b456f', '5d88cedef175132c008b456b', '5d88cf1af175132c008b4577'];
 $ const upcomingQueryParams = {
   includeContentTypes: ["Webinar"],
   queryFragment,
   beginningAfter: mailDate,
-  limit: 2,
+  limit: upcomingLimit,
   sort: {
     field: "startDate",
     order: "asc",
@@ -31,7 +33,6 @@ $ const archiveQueryParams = {
     field: "startDate",
     order: "desc",
   },
-  limit: 1,
 };
 
 $ const sectionNameStyle = {
@@ -65,8 +66,8 @@ $ const sectionNameStyle = {
               params: upcomingQueryParams,
             });
             <marko-web-resolve|{ resolved }| promise=upcomingPromise>
-              $ const { schedules } = resolved
-              <for|content| of=schedules>
+              $ const { schedules: upcoming } = resolved
+              <for|content| of=upcoming>
                 $ const contentLinkUrl = new URL(content.linkUrl);
                 $ const { searchParams } = contentLinkUrl
                 $ searchParams.set('ref', `${content.primarySite.shortName}-news`);
@@ -86,32 +87,36 @@ $ const sectionNameStyle = {
                   </td>
                 </tr>
               </for>
-            </marko-web-resolve>
-            $ const archivePromise = webinarLoader(apollo, { 
-              siteIds,
-              params: archiveQueryParams,
-            });
-            <marko-web-resolve|{ resolved }| promise=archivePromise>
-              $ const { schedules } = resolved
-              <for|content| of=schedules>
-                $ const contentLinkUrl = new URL(content.linkUrl);
-                $ const { searchParams } = contentLinkUrl
-                $ searchParams.set('ref', `${content.primarySite.shortName}-news`);
-                <tr>
-                  <td align="left" style="padding:0;margin:0;padding-bottom:5px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;letter-spacing:0;color:#999999;font-size:14px">
-                    Now Available On-Demand
-                  </td>
-                </tr>  
-                <tr>
-                  <td align="left" style="padding:0;margin:0;padding-bottom:20px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;letter-spacing:0;color:#333333;font-size:14px">
-                    <strong>
-                      <a href=`${contentLinkUrl}` target="_blank" style="mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
-                        ${content.name}
-                      </a>
-                    </strong>
-                  </td>
-                </tr>
-              </for>
+              $ const archiveLimit = displayLimit - upcoming.length
+              <if(archiveLimit !== 0)>
+                $ const archivePromise = webinarLoader(apollo, { 
+                  siteIds,
+                  params: archiveQueryParams,
+                  limit: archiveLimit,
+                });
+                <marko-web-resolve|{ resolved }| promise=archivePromise>
+                  $ const { archives } = resolved
+                  <for|content| of=archives>
+                    $ const contentLinkUrl = new URL(content.linkUrl);
+                    $ const { searchParams } = contentLinkUrl
+                    $ searchParams.set('ref', `${content.primarySite.shortName}-news`);
+                    <tr>
+                      <td align="left" style="padding:0;margin:0;padding-bottom:5px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;letter-spacing:0;color:#999999;font-size:14px">
+                        Now Available On-Demand
+                      </td>
+                    </tr>  
+                    <tr>
+                      <td align="left" style="padding:0;margin:0;padding-bottom:20px;mso-line-height-rule:exactly;font-family:arial, 'helvetica neue', helvetica, sans-serif;line-height:21px;letter-spacing:0;color:#333333;font-size:14px">
+                        <strong>
+                          <a href=`${contentLinkUrl}` target="_blank" style="mso-line-height-rule:exactly;text-decoration:none;color:#333333;font-size:14px">
+                            ${content.name}
+                          </a>
+                        </strong>
+                      </td>
+                    </tr>
+                  </for>
+                </marko-web-resolve>
+              </if>
             </marko-web-resolve>
           </table>
         </td>


### PR DESCRIPTION
Ajust the logic on the webinars block to allow for back fill of the Webinars block.  Meaning it will attempt to populate it with 2 upcoming and then back fill the 3 item display limit with archived webinars.

https://trello.com/c/kcRWtfvy/1069-update-logic-for-webinar-section-of-newsletters

<img width="698" alt="Screenshot 2025-05-09 at 9 17 47 AM" src="https://github.com/user-attachments/assets/438ea49d-e2f5-4f34-9ca6-ed0126244731" />

<img width="762" alt="Screenshot 2025-05-09 at 9 27 47 AM" src="https://github.com/user-attachments/assets/6867bda5-8247-48ac-b531-74035970a093" />
<img width="893" alt="Screenshot 2025-05-09 at 9 27 59 AM" src="https://github.com/user-attachments/assets/d32377d1-fa3e-43d7-9426-d6d20e379dde" />
<img width="819" alt="Screenshot 2025-05-09 at 9 28 11 AM" src="https://github.com/user-attachments/assets/37d805bc-9a86-42eb-914d-22ed1024b061" />

Mundo:
<img width="549" alt="Screenshot 2025-05-09 at 9 39 41 AM" src="https://github.com/user-attachments/assets/fd184c7a-dd70-499c-87d2-0be2a27a5a18" />
<img width="774" alt="Screenshot 2025-05-09 at 9 38 47 AM" src="https://github.com/user-attachments/assets/4db260d4-5c72-458b-85a7-7134c03c0f0e" />

