### PR TITLE
Pack Expo revisions (img styling & padding adjustments)

### DIFF
--- a/packages/common/components/blocks/expo/content-list-item.marko
+++ b/packages/common/components/blocks/expo/content-list-item.marko
@@ -37,7 +37,7 @@ $ const imgStyles = {
                           alt=image.alt
                           options={ w: 440, auto: "format,compress", q: 100 }
                           class="img-max"
-                          attrs={ style: imgStyles }
+                          attrs={ width: 220, style: imgStyles }
                         >
                           <@link href=contentLink target="_blank" />
                         </marko-newsletter-imgix>
@@ -66,7 +66,7 @@ $ const imgStyles = {
                           </td>
                         </tr>
                         <tr>
-                          <td style="color: #636466; font-family: Helvetica, Arial, sans-serif; font-size: 14px; font-weight: normal; line-height: 22px;padding-bottom:8px;" align="left" class="body-text">
+                          <td style="color: #636466; font-family: Helvetica, Arial, sans-serif; font-size: 14px; font-weight: normal; line-height: 22px;" align="left" class="body-text">
                             $!{content.teaser}
                           </td>
                         </tr>

--- a/packages/common/components/blocks/expo/curated-mundo.marko
+++ b/packages/common/components/blocks/expo/curated-mundo.marko
@@ -20,7 +20,7 @@ $ const imgStyles = {
               alt="Seleccionado para ti"
               options={ w: 652, h: 68, auto: "format,compress", q: 100 }
               class="img-text-header"
-              attrs={ w: 326, h: 34, style: imgStyles }
+              attrs={ width: 326, height: 34, style: imgStyles }
             >
             </marko-newsletter-imgix>
           </td>
@@ -43,7 +43,7 @@ $ const imgStyles = {
                                 alt=""
                                 options={ w: 544, auto: "format,compress", q: 100 }
                                 class="img-max"
-                                attrs={ style:"max-width:272px; height: auto; width:100%;" }
+                                attrs={ width: 272, style:"max-width:272px; height: auto; width:100%;" }
                               >
                                 <@link href="https://www.packexpolasvegas.com/education/sustainability-central" target="_blank" />
                               </marko-newsletter-imgix>
@@ -92,7 +92,7 @@ $ const imgStyles = {
                                 alt=""
                                 options={ w: 544, auto: "format,compress", q: 100 }
                                 class="img-max"
-                                attrs={ style:"max-width:272px; height: auto; width:100%;" }
+                                attrs={ width: 272, style:"max-width:272px; height: auto; width:100%;" }
                               >
                                 <@link href="https://www.packexpolasvegas.com/education/innovation-stage" target="_blank" />
                               </marko-newsletter-imgix>

--- a/packages/common/components/blocks/expo/curated.marko
+++ b/packages/common/components/blocks/expo/curated.marko
@@ -20,7 +20,7 @@ $ const imgStyles = {
               alt="Curated for you"
               options={ w: 652, h: 68, auto: "format,compress", q: 100 }
               class="img-text-header"
-              attrs={ w: 326, h: 34, style: imgStyles }
+              attrs={ width: 326, height: 34, style: imgStyles }
             >
             </marko-newsletter-imgix>
           </td>
@@ -43,7 +43,7 @@ $ const imgStyles = {
                                 alt=""
                                 options={ w: 544, auto: "format,compress", q: 100 }
                                 class="img-max"
-                                attrs={ style:"max-width:272px; height: auto; width:100%;" }
+                                attrs={ width: 272, style:"max-width:272px; height: auto; width:100%;" }
                               >
                                 <@link href="https://www.packexpolasvegas.com/education/sustainability-central" target="_blank" />
                               </marko-newsletter-imgix>
@@ -92,7 +92,7 @@ $ const imgStyles = {
                                 alt=""
                                 options={ w: 544, auto: "format,compress", q: 100 }
                                 class="img-max"
-                                attrs={ style:"max-width:272px; height: auto; width:100%;" }
+                                attrs={ width: 272, style:"max-width:272px; height: auto; width:100%;" }
                               >
                                 <@link href="https://app.credspark.com/assessments/5ebc5436534e6-a2985215-1b69-4b92-85e7-cd875e0490f7/assessment_responses/new" target="_blank" />
                               </marko-newsletter-imgix>

--- a/packages/common/components/blocks/expo/exhibitor-search-mundo.marko
+++ b/packages/common/components/blocks/expo/exhibitor-search-mundo.marko
@@ -23,7 +23,7 @@ $ const imgStyles = {
                     alt="Encontrar expositores"
                     options={ w: 652, h: 68, auto: "format,compress", q: 100 }
                     class="img-text-header"
-                    attrs={ w: 326, h: 34, style: imgStyles }
+                    attrs={ width: 326, height: 34, style: imgStyles }
                   >
                   </marko-newsletter-imgix>
                 </td>

--- a/packages/common/components/blocks/expo/exhibitor-search.marko
+++ b/packages/common/components/blocks/expo/exhibitor-search.marko
@@ -23,7 +23,7 @@ $ const imgStyles = {
                     alt="Search Exhibitors"
                     options={ w: 652, h: 68, auto: "format,compress", q: 100 }
                     class="img-text-header"
-                    attrs={ w: 326, h: 34, style: imgStyles }
+                    attrs={ width: 326, height: 34, style: imgStyles }
                   >
                   </marko-newsletter-imgix>
                 </td>
@@ -43,7 +43,7 @@ $ const imgStyles = {
                                 alt=""
                                 options={ w: 564, h: 378, auto: "format,compress", q: 100 }
                                 class="img-med"
-                                attrs={ w: 282, style: "max-width:282px;max-height:189px;width:100%;" }
+                                attrs={ width: 282, style: "max-width:282px;max-height:189px;width:100%;" }
                               >
                                 <@link href="https://packexpo25.mapyourshow.com/8_0/#/" target="_blank" style="border:0;padding:0; margin:0;"/>
                               </marko-newsletter-imgix>
@@ -85,7 +85,7 @@ $ const imgStyles = {
                                 alt="Search Exhibitors"
                                 options={ w: 564, auto: "format,compress", q: 100 }
                                 class="img-med"
-                                attrs={ w: 282, style: "max-width:282px;max-height:189px;width:100%;" }
+                                attrs={ width: 282, style: "max-width:282px;max-height:189px;width:100%;" }
                               >
                                 <@link href="https://categories.packexpo.com/?utm_source=Live+From+PACK+EXPO&utm_medium=Email&utm_campaign=All+Days" target="_blank" style="border:0;padding:0; margin:0;" />
                               </marko-newsletter-imgix>

--- a/packages/common/components/blocks/expo/footer-mundo.marko
+++ b/packages/common/components/blocks/expo/footer-mundo.marko
@@ -21,7 +21,7 @@
                                 src="/files/base/pmmi/all/image/newsletters/pmg-250x121.png" 
                                 alt="PMG Logo"
                                 options={ w: 250, h: 120, auto: "format,compress", q: 100 }
-                                attrs={ w: 125, h: 60, style: "max-width:125px; max-height:60px" }
+                                attrs={ width: 125, height: 60, style: "max-width:125px; max-height:60px" }
                               >
                               </marko-newsletter-imgix>
                             </td>
@@ -47,7 +47,7 @@
                                 </tr>
                                 <tr>
                                   <td style="padding: 0 0 4px 0; color: #a5a5a5; font-family: Helvetica, Arial, sans-serif; font-size: 12px; font-weight: normal; line-height: 18px;" align="left">
-                                    PMMI, Oficina en América Latina, Homero No. 418 Piso 3
+                                    Col. Chapultepec Morales, Ciudad de México, México. CP 11570
                                   </td>
                                 </tr>
                                 <tr>

--- a/packages/common/components/blocks/expo/footer.marko
+++ b/packages/common/components/blocks/expo/footer.marko
@@ -21,7 +21,7 @@
                                 src="/files/base/pmmi/all/image/newsletters/pmg-250x121.png" 
                                 alt="PMG Logo"
                                 options={ w: 250, h: 120, auto: "format,compress", q: 100 }
-                                attrs={ w: 125, h: 60, style: "max-width:125px; max-height:60px" }
+                                attrs={ width: 125, height: 60, style: "max-width:125px; max-height:60px" }
                               >
                               </marko-newsletter-imgix>
                             </td>

--- a/packages/common/components/blocks/expo/header-mundo.marko
+++ b/packages/common/components/blocks/expo/header-mundo.marko
@@ -36,7 +36,7 @@ $ const displayDate = (lang) ? moment(date).locale(lang).format("LL") : moment(d
                                       src="/files/base/pmmi/all/image/newsletters/livefromPELV-ESP-WhiteBackground.png"
                                       options={ w: 302, h: "auto", auto: "format,compress", q: 100 }
                                       alt=newsletterName
-                                      attrs={ w: 151, height: "auto", style: "width:100%; max-width: 193px;" }
+                                      attrs={ width: 151, height: "auto", style: "width:100%; max-width: 193px;" }
                                       class="header-img-max"
                                     />
                                   </td>

--- a/packages/common/components/blocks/expo/header.marko
+++ b/packages/common/components/blocks/expo/header.marko
@@ -36,7 +36,7 @@ $ const displayDate = (lang) ? moment(date).locale(lang).format("LL") : moment(d
                                       src="/files/base/pmmi/all/image/newsletters/LiveFromPELVHeader.png"
                                       options={ w: 302, h: "auto", auto: "format,compress", q: 100 }
                                       alt=newsletterName
-                                      attrs={ w: 151, height: "auto", style: "width:100%; max-width: 193px;" }
+                                      attrs={ width: 151, height: "auto", style: "width:100%; max-width: 193px;" }
                                       class="header-img-max"
                                     />
                                   </td>

--- a/packages/common/components/blocks/expo/marko.json
+++ b/packages/common/components/blocks/expo/marko.json
@@ -55,5 +55,11 @@
   },
   "<common-expo-exhibitor-search-mundo-block>": {
     "template": "./exhibitor-search-mundo.marko"
+  },
+  "<common-expo-schedule-list-mundo-block>": {
+    "template": "./schedule-list-mundo.marko"
+  },
+  "<common-expo-schedule-list-item-mundo-block>": {
+    "template": "./schedule-list-item-mundo.marko"
   }
 }

--- a/packages/common/components/blocks/expo/schedule-list-item-mundo.marko
+++ b/packages/common/components/blocks/expo/schedule-list-item-mundo.marko
@@ -1,0 +1,74 @@
+import { get, getAsArray } from "@mindful-web/object-path";
+import defaultValue from "@mindful-web/marko-core/utils/default-value";
+import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+
+$ const { newsletter, date, content, sectionName } = input;
+
+<tr>
+  <td style="padding-bottom:16px;" align="center" valign="top" class="mobile-padding-topbtm">
+    <html-comment> Two column </html-comment>
+    <table border="0" cellpadding="0" cellspacing="0" width="100%">
+      <tr>
+        <td style="background-color:#dbdeff;border-radius:4px;padding:16px;" class="header">
+          <table border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <html-comment> content left </html-comment>
+              <td class="content-table-flex-main" style="width:68%;display:inline-block;padding-right: 16px;" valign="top">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" align="left">
+                  <tr>
+                    <td style="color: #000000; font-family: Helvetica, Arial, sans-serif; font-size: 12px;text-transform:uppercase;letter-spacing: .5px;font-weight: bold; padding: 0 0 8px 0;" align="left" class="body-text">
+                      $!{content.teaser}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="padding: 0 0 12px 0; color: #3a3636; font-family: Helvetica, Arial, sans-serif; font-size: 18px; font-weight: bold; line-height: 24px;">
+                      <a href=content.siteContext.url target="_blank" style="color: #3a3636; text-decoration: none;">
+                        $!{content.name}
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td style="color: #384198; font-family: Helvetica, Arial, sans-serif; font-size: 12px;letter-spacing:.5px; font-weight: bold; line-height: 22px;" class="eyebrowPurp">
+                      $!{content.body}
+                    </td>
+                  </tr>
+                </table>
+              </td>
+              <html-comment> /content left </html-comment>
+              <html-comment> content right </html-comment>
+              <td class="content-table-flex-main" style="width:150px;display:inline-block;text-align:right;">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" align="right">
+                  <html-comment> button </html-comment>
+                  <tr>
+                    <td align="center" style="text-align:center;padding-top:40px;" class="mobilepadding-btn">
+                      <table border="0" cellpadding="0" cellspacing="0" style="border-collapse:separate !important;width:100%;">
+                        <tr>
+                          <td align="center" valign="middle">
+                            <!--[if gte mso 9]>
+                              <table border="0" cellspacing="0" cellpadding="0" style="width:150px;">
+                                <tr>
+                                  <td align="center" bgcolor="#384198" style="padding:3px 2px;" valign="top" class="button">
+                            <![endif]-->
+                            <common-expo-action-link-block style="background-color:#384198;border-collapse:separate !important;border-top:4px solid #384198;border-right:2px solid #384198;border-bottom:4px solid #384198;border-left:2px solid #384198;color:#ffffff;display:inline-block;border-radius:4px;font-family:Helvetica, Arial, sans-serif;font-size:13px;letter-spacing: .8px;line-height:18px;text-align:center;text-decoration:none;font-weight:600;width: 150px; box-sizing: border-box;" content=content />
+                            <!--[if gte mso 9]>
+                                  </td>
+                                </tr>
+                              </table>
+                            <![endif]-->
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  <html-comment> /button </html-comment>
+                </table>
+              </td>
+              <html-comment> /content right </html-comment>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+    <html-comment> /Two column </html-comment>
+  </td>
+</tr>

--- a/packages/common/components/blocks/expo/schedule-list-mundo.marko
+++ b/packages/common/components/blocks/expo/schedule-list-mundo.marko
@@ -1,0 +1,21 @@
+import defaultValue from "@mindful-web/marko-core/utils/default-value";
+import queryFragment from "@pmmi-media-group/package-common/graphql/fragments/content-list";
+
+$ const { newsletter, date, sectionName } = input;
+
+$ const queryParams = {
+  date: date.valueOf(),
+  newsletterId: newsletter.id,
+  sectionName,
+  limit: input.limit || 1,
+  skip: input.skip || 0,
+  queryFragment,
+};
+
+<marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
+  <if(nodes.length)>
+    <for|content| of=nodes>
+      <common-expo-schedule-list-item-mundo-block content=content />
+    </for>
+  </if>
+</marko-web-query>

--- a/packages/common/components/blocks/expo/show-daily.marko
+++ b/packages/common/components/blocks/expo/show-daily.marko
@@ -35,7 +35,7 @@ $ const textImgStyles = {
                           alt=""
                           options={ w: 300, auto: "format,compress", q: 100 }
                           class="img-med"
-                          attrs={ style: imgStyles }
+                          attrs={ width: 150, style: imgStyles }
                         >
                         </marko-newsletter-imgix>
                       </td>
@@ -56,7 +56,7 @@ $ const textImgStyles = {
                                 alt="PACK EXPO International Show Daily"
                                 options={ w: 560, h: 68, auto: "format,compress", q: 100 }
                                 class="img-text-header"
-                                attrs={ w: 280, h: 34, style: textImgStyles }
+                                attrs={ width: 280, height: 34, style: textImgStyles }
                               >
                               </marko-newsletter-imgix>
                             </td>

--- a/packages/common/components/layouts/expo-mundo.marko
+++ b/packages/common/components/layouts/expo-mundo.marko
@@ -52,6 +52,7 @@ $ const displayDate = (lang) ? moment(date).locale(lang).format("LL") : moment(d
                         section-name="News"
                         limit=6
                       />
+                      <html-comment> Articles end </html-comment>
                     </table>
                   </td>
                 </tr>
@@ -144,7 +145,7 @@ $ const displayDate = (lang) ? moment(date).locale(lang).format("LL") : moment(d
                 </tr>
 
                 <html-comment> Scheduled Items begin </html-comment>
-                <common-expo-schedule-list-block 
+                <common-expo-schedule-list-mundo-block 
                   newsletter=newsletter
                   date=date
                   section-name="Schedule"

--- a/packages/common/components/layouts/expo.marko
+++ b/packages/common/components/layouts/expo.marko
@@ -51,6 +51,7 @@ $ const displayDate = moment(date).add(1, "days").format("dddd, MMMM D");
                         section-name="News"
                         limit=6
                       />
+                      <html-comment> Articles end </html-comment>
                       
                       <html-comment> Editorial View ALl </html-comment>
                       <tr>


### PR DESCRIPTION
<img width="658" height="208" alt="Screenshot 2025-09-24 at 8 10 12 AM" src="https://github.com/user-attachments/assets/36e58acd-44ce-4892-92d8-ce49d7b20e1f" />
<img width="710" height="218" alt="Screenshot 2025-09-24 at 8 11 25 AM" src="https://github.com/user-attachments/assets/1e473807-1c02-4932-bd32-e17832070a9b" />
