### PR TITLE
Adjust displayDate to display tomorrow’s date

### DIFF
--- a/packages/common/components/layouts/expo-mundo.marko
+++ b/packages/common/components/layouts/expo-mundo.marko
@@ -12,7 +12,7 @@ $ const newsletterDescription = stripHtml(get(newsletterConfig, "description"));
 $ const title = get(newsletterConfig, "title");
 $ const lang = get(newsletterConfig, "lang");
 
-$ const displayDate = (lang) ? moment(date).locale(lang).format("LL") : moment(date).format("LL");
+$ const displayDate = (lang) ? moment(date).add(1, "days").locale(lang).format("LL") : moment(date).format("LL");
 
 <marko-newsletter-root
   title=title


### PR DESCRIPTION
Newsletter date 9/30 'Up Next' section displays 10/1

<img width="511" height="843" alt="Screenshot 2025-09-24 at 11 44 15 AM" src="https://github.com/user-attachments/assets/5a008354-8510-4669-8b5d-6784ab7b88ef" />
