### PR TITLE
Fix most popular content API URL

### DIFF
--- a/packages/common/components/layouts/automated.marko
+++ b/packages/common/components/layouts/automated.marko
@@ -33,7 +33,7 @@ $ const queryParams = {
 $ const blockName = "most-popular";
 
 $ const getMostPopular = async (ids) => {
-  const uri = MOST_POPULAR_API_URI || 'https://apis.internal.mindfulcms.com/most-popular';
+  const uri = MOST_POPULAR_API_URI || 'https://apis.mindfulcms.com/most-popular';
 
   const url = `${uri}/retrieve?tenant=${tenant}&realm=${realm}&includeIds=${ids.join(',')}`;
   const res = await fetch(url);

--- a/packages/common/components/layouts/automated.marko
+++ b/packages/common/components/layouts/automated.marko
@@ -33,7 +33,7 @@ $ const queryParams = {
 $ const blockName = "most-popular";
 
 $ const getMostPopular = async (ids) => {
-  const uri = MOST_POPULAR_API_URI || 'https://most-popular-content.mindful-web.parameter1.com';
+  const uri = MOST_POPULAR_API_URI || 'https://apis.internal.mindfulcms.com/most-popular';
 
   const url = `${uri}/retrieve?tenant=${tenant}&realm=${realm}&includeIds=${ids.join(',')}`;
   const res = await fetch(url);


### PR DESCRIPTION
## Summary

- Replaces the hardcoded fallback URL `https://most-popular-content.mindful-web.parameter1.com` with the new consolidated endpoint `https://apis.internal.mindfulcms.com/most-popular` in `packages/common/components/layouts/automated.marko`.
- The `MOST_POPULAR_API_URI` env var override continues to work as before; this change only updates the hardcoded default.

## Test plan

- [ ] Verify newsletters that use the automated layout still render most-popular content correctly after deploy.
- [ ] Confirm `MOST_POPULAR_API_URI` env var override still takes precedence when set.